### PR TITLE
feat: Reusable <Button> component with Tailwind CSS and demo page

### DIFF
--- a/Frontend/EduLiteFrontend/package-lock.json
+++ b/Frontend/EduLiteFrontend/package-lock.json
@@ -12,6 +12,7 @@
         "@tailwindcss/vite": "^4.1.7",
         "i18next": "^25.1.3",
         "lucide-react": "^0.510.0",
+        "prop-types": "^15.8.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-i18next": "^15.5.1",
@@ -2937,7 +2938,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -3275,6 +3275,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3461,7 +3473,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3672,6 +3683,17 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -3793,6 +3815,12 @@
       "peerDependencies": {
         "react": "*"
       }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",

--- a/Frontend/EduLiteFrontend/package.json
+++ b/Frontend/EduLiteFrontend/package.json
@@ -13,6 +13,7 @@
     "@tailwindcss/vite": "^4.1.7",
     "i18next": "^25.1.3",
     "lucide-react": "^0.510.0",
+    "prop-types": "^15.8.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-i18next": "^15.5.1",

--- a/Frontend/EduLiteFrontend/src/App.jsx
+++ b/Frontend/EduLiteFrontend/src/App.jsx
@@ -2,6 +2,8 @@
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
 import Navbar from './components/Navbar'
 import Home from './pages/Home'
+import ButtonDemo from './pages/ButtonDemo'
+
 function App() {
   return (
     <Router>
@@ -10,6 +12,7 @@ function App() {
         <Routes>
           <Route path="/" element={<h1 className="text-2xl font-bold"><Home /></h1>} />
           <Route path="/about" element={<h1 className="text-2xl font-bold">About Page</h1>} />
+          <Route path="/button-demo" element={<ButtonDemo />} />
         </Routes>
       </div>
     </Router>

--- a/Frontend/EduLiteFrontend/src/components/common/Button.jsx
+++ b/Frontend/EduLiteFrontend/src/components/common/Button.jsx
@@ -1,0 +1,88 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+/**
+ * Reusable Button component for EduLite, styled with Tailwind CSS.
+ *
+ * Props:
+ * - children: Content inside the button (text, icon, etc.)
+ * - onClick: Click handler function
+ * - type: 'primary' | 'secondary' | 'danger' (visual style)
+ * - size: 'sm' | 'md' | 'lg' (button size)
+ * - disabled: If true, button is disabled
+ * - className: Additional Tailwind classes
+ * - ...rest: Any other button attributes (e.g., aria-label)
+ *
+ * Usage examples:
+ * <Button onClick={...}>Default</Button>
+ * <Button type="secondary" size="sm">Secondary Small</Button>
+ * <Button type="danger" disabled>Delete</Button>
+ */
+const baseStyles =
+  "inline-flex items-center justify-center font-medium rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed";
+
+const typeStyles = {
+  primary:
+    "bg-blue-600 text-white hover:bg-blue-700 focus-visible:ring-blue-500",
+  secondary:
+    "bg-white text-blue-700 border border-blue-600 hover:bg-blue-50 focus-visible:ring-blue-400",
+  danger:
+    "bg-red-600 text-white hover:bg-red-700 focus-visible:ring-red-500",
+};
+
+const sizeStyles = {
+  sm: "px-3 py-1.5 text-sm",
+  md: "px-4 py-2 text-base",
+  lg: "px-6 py-3 text-lg",
+};
+
+const Button = React.forwardRef(
+  (
+    {
+      children,
+      onClick,
+      type = "primary",
+      size = "md",
+      disabled = false,
+      className = "",
+      ...rest
+    },
+    ref
+  ) => {
+    const style = [
+      baseStyles,
+      typeStyles[type] || typeStyles.primary,
+      sizeStyles[size] || sizeStyles.md,
+      className,
+    ]
+      .filter(Boolean)
+      .join(" ");
+
+    return (
+      <button
+        ref={ref}
+        type="button"
+        className={style}
+        onClick={onClick}
+        disabled={disabled}
+        aria-disabled={disabled}
+        {...rest}
+      >
+        {children}
+      </button>
+    );
+  }
+);
+
+Button.displayName = "Button";
+
+Button.propTypes = {
+  children: PropTypes.node.isRequired,
+  onClick: PropTypes.func,
+  type: PropTypes.oneOf(["primary", "secondary", "danger"]),
+  size: PropTypes.oneOf(["sm", "md", "lg"]),
+  disabled: PropTypes.bool,
+  className: PropTypes.string,
+};
+
+export default Button;

--- a/Frontend/EduLiteFrontend/src/pages/ButtonDemo.jsx
+++ b/Frontend/EduLiteFrontend/src/pages/ButtonDemo.jsx
@@ -1,0 +1,30 @@
+import React from "react";
+import Button from "../components/common/Button";
+
+// Demo page to showcase the Button component with different props
+const ButtonDemo = () => (
+  <div className="p-8 space-y-6 bg-gray-50 min-h-screen">
+    <h1 className="text-2xl font-bold mb-4">Button Component Demo</h1>
+    <div className="space-x-4">
+      <Button onClick={() => alert('Primary clicked!')}>Primary (default)</Button>
+      <Button type="secondary" onClick={() => alert('Secondary clicked!')}>Secondary</Button>
+      <Button type="danger" onClick={() => alert('Danger clicked!')}>Danger</Button>
+    </div>
+    <div className="space-x-4">
+      <Button size="sm">Small</Button>
+      <Button size="md">Medium</Button>
+      <Button size="lg">Large</Button>
+    </div>
+    <div className="space-x-4">
+      <Button disabled>Disabled</Button>
+      <Button type="secondary" disabled>Disabled Secondary</Button>
+      <Button type="danger" disabled>Disabled Danger</Button>
+    </div>
+    <div className="space-x-4">
+      <Button className="uppercase tracking-widest">Custom Class</Button>
+      <Button aria-label="Accessible Button">With aria-label</Button>
+    </div>
+  </div>
+);
+
+export default ButtonDemo;


### PR DESCRIPTION

Implements a flexible, accessible, and reusable <Button> component with Tailwind CSS.

1. Adds a demo page at /button-demo to showcase all button variants and states.
2. Installs prop-types for prop validation.
3. Updates routing to include the demo page.
How to test:

- Run the frontend dev server.
- Visit /button-demo to see and interact with all button variants.
- Expected behavior:

The Button component is reusable, customizable, and consistent across the app.
The demo page displays all button types, sizes, and states.

Actual behavior before this PR:
No reusable button component button styles were duplicated or inconsistent.
Environment:

