### PR TITLE
Add full_name field to UserSerializer

### DIFF
--- a/backend/EduLite/users/serializers.py
+++ b/backend/EduLite/users/serializers.py
@@ -67,6 +67,7 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):  # Or ModelSeriali
         view_name="userprofile-detail",
         read_only=True,
     )
+    full_name = serializers.SerializerMethodField()
 
     class Meta:
         model = User
@@ -79,7 +80,19 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):  # Or ModelSeriali
             "groups",
             "first_name",
             "last_name",
+            "full_name",
         ]
+        
+    def get_full_name(self, obj):
+        first = obj.first_name
+        last = obj.last_name
+        if first and last:
+            return f"{first} {last}"
+        elif first:
+            return first
+        elif last:
+            return last
+        return "" 
 
 
 ## -- Secure Password Hashing Serializers -- ##


### PR DESCRIPTION
### Changes Made:
- Added `full_name` field to `UserSerializer` using `SerializerMethodField`
- Combines `first_name` and `last_name` with clean formatting
- Handles cases where one or both names are missing

### Why:
This helps frontend clients by providing a pre-formatted full name directly from the API, reducing the need for client-side logic.

Closes #49