### PR TITLE
added userprofile language validation

### DIFF
--- a/backend/EduLite/users/models.py
+++ b/backend/EduLite/users/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.contrib.auth import get_user_model
 from django.db import transaction, IntegrityError
+from django.core.exceptions import ValidationError
 
 
 from .models_choices import OCCUPATION_CHOICES, COUNTRY_CHOICES, LANGUAGE_CHOICES
@@ -32,6 +33,15 @@ class UserProfile(models.Model):
     website_url = models.URLField(max_length=200, blank=True, null=True)
 
     friends = models.ManyToManyField(User, related_name="friend_profiles", blank=True)
+
+
+    def clean(self):
+        super().clean()  # Call parent clean()
+        if self.preferred_language and self.secondary_language:
+            if self.preferred_language == self.secondary_language:
+                raise ValidationError({
+                    'secondary_language': "Secondary language cannot be the same as the preferred language."
+                })
 
     def __str__(self):
         ret_str = f"{self.user.username}"


### PR DESCRIPTION
This pull request adds a custom validation to the UserProfile model to ensure that the secondary_language cannot be the same as the preferred_language.


✅ What’s Changed
	•	Overridden the clean() method in UserProfile
	•	Raises a ValidationError if both languages are set and identical


Related Issue
Closes #47

<img width="785" alt="Screenshot 2025-06-18 at 11 34 36 PM" src="https://github.com/user-attachments/assets/b5783147-3c79-4a48-b6ff-774c7eeb9ed5" />
