### PR TITLE
Made about us page responsive by changing padding

### DIFF
--- a/Frontend/EduLiteFrontend/src/App.jsx
+++ b/Frontend/EduLiteFrontend/src/App.jsx
@@ -10,7 +10,7 @@ function App() {
   return (
     <Router>
       <Navbar />
-      <div className="pt-20 px-4">
+      <div className="pt-10 px-0">
         <Routes>
           <Route
             path="/"

--- a/Frontend/EduLiteFrontend/src/pages/AboutPage.jsx
+++ b/Frontend/EduLiteFrontend/src/pages/AboutPage.jsx
@@ -22,7 +22,7 @@ const AboutPage = () => {
     <div className="text-gray-800 dark:text-gray-100 bg-white dark:bg-gray-900 min-h-screen overflow-hidden">
       {/* Animated Hero Section */}
       <section
-        className="relative h-screen flex items-center justify-center px-6 md:px-16 overflow-hidden"
+        className="relative h-screen pt-12 flex items-center justify-center px-6 md:px-16 overflow-hidden"
         style={{ height: "calc(100vh - 80px)" }}
       >
         {/* Animated Background Elements */}
@@ -67,9 +67,9 @@ const AboutPage = () => {
         </div>
 
         <div className="relative max-w-6xl mx-auto text-center z-10">
-          <div className="mb-8">
-            <div className="inline-block p-4 bg-gradient-to-r from-blue-500 to-purple-600 rounded-3xl shadow-2xl mb-8">
-              <FaGraduationCap className="text-4xl text-white" />
+          <div className="mb-4">
+            <div className="inline-block p-3 sm:p-4 md:p-6 bg-gradient-to-r from-blue-500 to-purple-600 rounded-3xl shadow-2xl mb-4">
+              <FaGraduationCap className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl text-white"  />
             </div>
           </div>
 


### PR DESCRIPTION
Summary of changes:

Changed mb-8 to mb-4 in two places for better spacing.

Made the logo responsive so it no longer gets cut off on smaller screens (like iPhone SE).

Improved layout and spacing for the About page on mobile devices.

<img width="1467" alt="Screenshot 2025-06-20 at 8 19 56 PM" src="https://github.com/user-attachments/assets/62a4e81d-cc6d-4f4a-a63c-2d57a520d1e1" />


Example of webpage on Iphone SE using dev tools. 