### PR TITLE
Added 'Component Showcase' table in the frontend readme

### DIFF
--- a/Frontend/README.md
+++ b/Frontend/README.md
@@ -79,3 +79,10 @@ these routs are defined in `src/App.jsx` using `react-router-dom` library.
 | `/login`  | `LoginPage`  | Allows users to sign in.                                   |
 | `/signup` | `SignUpPage` | Allows new users to register.                              |
 | `/about`  | `AboutPage`  | This page provides an overview of the project, it's goals. |
+
+## ✨ Component Showcase
+
+| Component | Description  | Demo Page |
+| --------- | ------------ | --------- | 
+| `Button`  | A versatile button with multiple styles and sizes. | `/button-demo` |
+| `Input`   | An Apple-style input field for forms. | `/input-demo` |


### PR DESCRIPTION
Added the 'Component Showcase' table which lists the components with their respective demo pages to ease the development. 

Issue [#112](https://github.com/ibrahim-sisar/EduLite/issues/112)