### PR TITLE
fix: update docker-compose reference

### DIFF
--- a/Docker-Files/containers.sh
+++ b/Docker-Files/containers.sh
@@ -71,8 +71,8 @@ check_docker_daemon() {
     echo "Error: Docker daemon is not running. Please start Docker and try again."
     exit 1
   fi
-  if ! docker-compose --version > /dev/null 2>&1; then
-    echo "Error: docker-compose is not installed or not in PATH. Please install it."
+  if ! docker compose --version > /dev/null 2>&1; then
+    echo "Error: docker compose is not installed or not in PATH. Please install it."
     exit 1
   fi
 }


### PR DESCRIPTION
## Overview
This pull request includes a small change to the `Docker-Files/containers.sh` script. The change updates the check for `docker-compose` to use the newer `docker compose` syntax.

The [docs mention](https://github.com/ibrahim-sisar/EduLite/blob/main/Docker-Files/DOCKER-README.md#prerequisites) that `docker compose` is the used syntax.

I didn't see an open issue for this, but happy to create one for tracking if desired. 

## Fixes Error

```
% ./containers.sh build
Error: docker-compose is not installed or not in PATH. Please install it.
```