### PR TITLE
feature: adds drf-spectacular for api auto-docs

### DIFF
--- a/backend/EduLite/EduLite/settings.py
+++ b/backend/EduLite/EduLite/settings.py
@@ -55,6 +55,8 @@ INSTALLED_APPS = [
     "rest_framework_simplejwt",
     "rest_framework_simplejwt.token_blacklist",
     "corsheaders",
+    'drf_spectacular',
+    'drf_spectacular_sidecar',
 ]
 
 LOGGING = {
@@ -200,11 +202,11 @@ STATIC_URL = "static/"
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
-
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework_simplejwt.authentication.JWTAuthentication",
     ],
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
 }
 
 from datetime import timedelta
@@ -267,3 +269,14 @@ EMAIL_HOST_USER = ''
 EMAIL_HOST_PASSWORD = ''
 DEFAULT_FROM_EMAIL = 'EduLite <noreply@edulite.local>'
 FRONTEND_URL = 'http://127.0.0.1:8000/api'
+
+# Spectacular settings for OpenAPI schema generation
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'EduLite API',
+    'DESCRIPTION': 'API documentation for EduLite',
+    'SERVE_INCLUDE_SCHEMA': False,
+    # configure sidecar for serving static files
+    'SWAGGER_UI_DIST': 'SIDECAR',
+    'SWAGGER_UI_FAVICON_HREF': 'SIDECAR',
+    'REDOC_DIST': 'SIDECAR',
+}

--- a/backend/EduLite/EduLite/urls.py
+++ b/backend/EduLite/EduLite/urls.py
@@ -2,7 +2,11 @@
 
 from django.contrib import admin
 from django.urls import path, include
-
+from drf_spectacular.views import (
+    SpectacularAPIView,
+    SpectacularSwaggerView,
+    SpectacularRedocView
+)
 from rest_framework_simplejwt.views import (
     TokenObtainPairView,
     TokenRefreshView,
@@ -20,4 +24,7 @@ urlpatterns = [
     # Our own URLs
     path("api/", include("users.urls")),
     path("api/chat/", include("chat.urls")),
+    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('swagger/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger'),
+    path('redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
 ]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -33,3 +33,5 @@ txaio==25.6.1
 typing_extensions==4.13.2
 tzdata==2025.2
 zope.interface==7.2
+drf-spectacular==0.28.0
+drf-spectacular-sidecar==2025.7.1


### PR DESCRIPTION
This pull request introduces API documentation support using `drf-spectacular` and enhances the Chat app's API with detailed schema definitions and examples. The most important changes include adding `drf-spectacular` dependencies, updating settings for schema generation, configuring API documentation endpoints, and annotating Chat app views with OpenAPI schema details.

### API Documentation Integration:

* Added `drf-spectacular` and `drf-spectacular-sidecar` to the project dependencies in `backend/requirements.txt` and installed them in `INSTALLED_APPS` in `settings.py`. [[1]](diffhunk://#diff-a780f027052bed3bff6ce9850db4a0e66358b86503cf4586e846ce88afa2e9bcR36-R37) [[2]](diffhunk://#diff-59df5de09c2a83d9aebc1591c8771c898ed31639cfb5f5a65b461e1ae58aa4fdR58-R59)
* Configured `SPECTACULAR_SETTINGS` in `settings.py` to define the API title, description, and static file serving for Swagger and Redoc.
* Set `DEFAULT_SCHEMA_CLASS` in `REST_FRAMEWORK` to use `drf-spectacular` for schema generation.

### API Documentation Endpoints:

* Added routes in `urls.py` for schema generation (`/api/schema/`), Swagger UI (`/swagger/`), and Redoc (`/redoc/`). [[1]](diffhunk://#diff-1f5d2e57d422513f3d2d8d8245ec2e669a23906818e74169bba4a224300b4daeL5-R9) [[2]](diffhunk://#diff-1f5d2e57d422513f3d2d8d8245ec2e669a23906818e74169bba4a224300b4daeR27-R29)

### Chat App Enhancements:

* Annotated `ChatRoomListCreateView` in `views.py` with `@extend_schema` to document request parameters, responses, and examples for `GET` and `POST` methods. This includes detailed descriptions for paginated responses, validation errors, and authentication errors. [[1]](diffhunk://#diff-30fa2a04e4aca84291cefc87fdb6b3789f2e67f2458077fb3e60b64d21d61929L29-R50) [[2]](diffhunk://#diff-30fa2a04e4aca84291cefc87fdb6b3789f2e67f2458077fb3e60b64d21d61929R78-R128) [[3]](diffhunk://#diff-30fa2a04e4aca84291cefc87fdb6b3789f2e67f2458077fb3e60b64d21d61929R144-R206)
* Introduced inline serializers for OpenAPI schema definitions to provide structured response examples for the Chat app's endpoints. [[1]](diffhunk://#diff-30fa2a04e4aca84291cefc87fdb6b3789f2e67f2458077fb3e60b64d21d61929R78-R128) [[2]](diffhunk://#diff-30fa2a04e4aca84291cefc87fdb6b3789f2e67f2458077fb3e60b64d21d61929R144-R206)