### PR TITLE
bug: fix compute_friend_suggestion imports

### DIFF
--- a/backend/EduLite/users/management/commands/compute_friend_suggestions.py
+++ b/backend/EduLite/users/management/commands/compute_friend_suggestions.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
-from EduLite.users.models import User
-from EduLite.users.services.friend_suggestions import compute_friend_suggestions_for_user
+from users.models import User
+from users.logic.friend_suggestions import compute_friend_suggestions_for_user
 
 class Command(BaseCommand):
     help = "Compute friend suggestions for all users"


### PR DESCRIPTION
## Overview
This pull request makes a small update to the import paths in the `compute_friend_suggestions.py` management command to use the correct module locations for `User` and `compute_friend_suggestions_for_user`.

Part of: https://github.com/ibrahim-sisar/EduLite/issues/73

## How to run
```
% python ./manage.py compute_friend_suggestions
Friend suggestions computed.
```
