### PR TITLE
168 issue typescript setup initial component migration

### DIFF
--- a/Frontend/EduLiteFrontend/README.md
+++ b/Frontend/EduLiteFrontend/README.md
@@ -1,3 +1,32 @@
+## TypeScript Support
+
+EduLite frontend now supports TypeScript! We're gradually migrating from JavaScript to TypeScript to improve code quality, developer experience, and maintainability.
+
+### TypeScript Status
+- ✅ TypeScript configured and ready
+- ✅ Components migrated: `Button.tsx`, `Input.tsx`
+- 🚧 Gradual migration in progress
+- ✅ JavaScript files still fully supported
+
+### Available Scripts
+
+```bash
+npm run dev          # Start development server (works with both JS and TS)
+npm run build        # Build for production (handles TS automatically)
+npm run type-check   # Run TypeScript type checking
+npm run lint         # Lint all files
+npm run preview     # Preview production build
+```
+
+### TypeScript Configuration
+
+Our `tsconfig.json` is configured for:
+- React JSX support
+- ES2020 target
+- Strict type checking
+- JavaScript interoperability (`allowJs: true`)
+- Path aliases (`@/` maps to `./src/`)
+
 ## Project Architecture
 
 ### Folder Structure
@@ -6,7 +35,8 @@
 src/
 ├── components/
 │   ├── common/           # Reusable UI components
-│   │   ├── Button.jsx
+│   │   ├── Button.tsx    # TypeScript ✅
+│   │   ├── Input.tsx     # TypeScript ✅
 │   │   └── BackToTopButton.jsx
 │   ├── DarkModeToggle.jsx
 │   ├── LanguageSwitcher.jsx
@@ -103,6 +133,47 @@ Button.propTypes = {
 
 export default Button;
 ```
+
+### TypeScript Migration Guide
+
+When converting a component from JavaScript to TypeScript:
+
+#### 1. Change file extension from `.jsx` to `.tsx`
+
+#### 2. Replace PropTypes with TypeScript interfaces:
+
+**Before (JavaScript with PropTypes):**
+```jsx
+Button.propTypes = {
+  children: PropTypes.node.isRequired,
+  onClick: PropTypes.func,
+  type: PropTypes.oneOf(["primary", "secondary", "danger"]),
+  disabled: PropTypes.bool,
+};
+```
+
+**After (TypeScript):**
+```tsx
+interface ButtonProps {
+  children: ReactNode;
+  onClick?: () => void;
+  type?: "primary" | "secondary" | "danger";
+  disabled?: boolean;
+}
+```
+
+#### 3. Add proper typing to React.forwardRef:
+```tsx
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ children, onClick, ...props }, ref) => {
+    // Component implementation
+  }
+);
+```
+
+#### 4. Remove PropTypes import and validation code
+
+#### 5. Test with `npm run type-check` to ensure no type errors
 
 ### Coding Standards for Common Components
 

--- a/Frontend/EduLiteFrontend/package-lock.json
+++ b/Frontend/EduLiteFrontend/package-lock.json
@@ -24,6 +24,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
+        "@types/node": "^24.5.2",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^4.4.1",
@@ -31,6 +32,7 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^16.0.0",
+        "typescript": "^5.9.2",
         "vite": "^6.3.5"
       }
     },
@@ -1616,6 +1618,15 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
+      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
+      "devOptional": true,
+      "dependencies": {
+        "undici-types": "~7.12.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.1.4",
@@ -4425,6 +4436,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "devOptional": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
+      "devOptional": true
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/Frontend/EduLiteFrontend/package.json
+++ b/Frontend/EduLiteFrontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.7",
@@ -25,6 +26,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
+    "@types/node": "^24.5.2",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",
@@ -32,6 +34,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
+    "typescript": "^5.9.2",
     "vite": "^6.3.5"
   },
   "description": "This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.",

--- a/Frontend/EduLiteFrontend/src/components/common/Button.tsx
+++ b/Frontend/EduLiteFrontend/src/components/common/Button.tsx
@@ -1,17 +1,41 @@
-import React from "react";
-import PropTypes from "prop-types";
+import React, { ButtonHTMLAttributes, ReactNode, MouseEventHandler } from "react";
+
+/**
+ * Type definitions for Button component styling options
+ */
+type ButtonType = "primary" | "secondary" | "danger";
+type ButtonSize = "sm" | "md" | "lg";
+type ButtonWidth = "auto" | "full" | "half" | "one-third" | "two-thirds" | "one-fourth" | "three-fourths";
+
+/**
+ * TypeScript interface for Button component props
+ * Extends HTML button attributes for full compatibility
+ */
+interface ButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onClick' | 'type' | 'className'> {
+  /** Content inside the button (text, icon, etc.) */
+  children: ReactNode;
+
+  /** Click handler function */
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+
+  /** Visual style of the button */
+  type?: ButtonType;
+
+  /** Button size variant */
+  size?: ButtonSize;
+
+  /** Width variant of the button */
+  width?: ButtonWidth;
+
+  /** Whether the button is disabled */
+  disabled?: boolean;
+
+  /** Additional CSS classes */
+  className?: string;
+}
 
 /**
  * Reusable Button component for EduLite, styled with Tailwind CSS.
- *
- * Props:
- * - children: Content inside the button (text, icon, etc.)
- * - onClick: Click handler function
- * - type: 'primary' | 'secondary' | 'danger' (visual style)
- * - size: 'sm' | 'md' | 'lg' (button size)
- * - disabled: If true, button is disabled
- * - className: Additional Tailwind classes
- * - ...rest: Any other button attributes (e.g., aria-label)
  *
  * Usage examples:
  * <Button onClick={...}>Default</Button>
@@ -25,7 +49,7 @@ const baseStyles =
   "disabled:opacity-50 disabled:cursor-not-allowed " +
   "active:scale-[.98]";
 
-const typeStyles = {
+const typeStyles: Record<ButtonType, string> = {
   primary:
     "bg-blue-600 text-white hover:bg-blue-700 focus-visible:ring-blue-500",
   secondary:
@@ -33,13 +57,13 @@ const typeStyles = {
   danger: "bg-red-600 text-white hover:bg-red-700 focus-visible:ring-red-500",
 };
 
-const sizeStyles = {
+const sizeStyles: Record<ButtonSize, string> = {
   sm: "px-3 py-1.5 text-sm",
   md: "px-4 py-2 text-base",
   lg: "px-6 py-3 text-lg",
 };
 
-const widthStyles = {
+const widthStyles: Record<ButtonWidth, string> = {
   auto: "w-auto",
   full: "w-full",
   half: "w-1/2",
@@ -49,7 +73,7 @@ const widthStyles = {
   "three-fourths": "w-3/4",
 };
 
-const Button = React.forwardRef(
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
       children,
@@ -61,7 +85,7 @@ const Button = React.forwardRef(
       className = "",
       ...rest
     },
-    ref,
+    ref
   ) => {
     const style = [
       baseStyles,
@@ -86,19 +110,9 @@ const Button = React.forwardRef(
         {children}
       </button>
     );
-  },
+  }
 );
 
 Button.displayName = "Button";
-
-Button.propTypes = {
-  children: PropTypes.node.isRequired,
-  onClick: PropTypes.func,
-  type: PropTypes.oneOf(["primary", "secondary", "danger"]),
-  size: PropTypes.oneOf(["sm", "md", "lg"]),
-  width: PropTypes.oneOf(Object.keys(widthStyles)),
-  disabled: PropTypes.bool,
-  className: PropTypes.string,
-};
 
 export default Button;

--- a/Frontend/EduLiteFrontend/src/components/common/Input.tsx
+++ b/Frontend/EduLiteFrontend/src/components/common/Input.tsx
@@ -1,12 +1,50 @@
-import React from "react";
-import PropTypes from "prop-types";
+import React, { ChangeEvent, InputHTMLAttributes } from "react";
+
+/**
+ * TypeScript interface for Input component props
+ * Extends HTML input attributes for full compatibility
+ */
+interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'className'> {
+  /** The input type (text, email, password, etc.) */
+  type?: string;
+
+  /** The name attribute for the input */
+  name: string;
+
+  /** Placeholder text */
+  placeholder?: string;
+
+  /** Current input value */
+  value: string;
+
+  /** Change handler function */
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+
+  /** Optional label text displayed above the input */
+  label?: string;
+
+  /** Error message to display below the input */
+  error?: string;
+
+  /** Whether the input is disabled */
+  disabled?: boolean;
+
+  /** Whether the input is required */
+  required?: boolean;
+
+  /** Additional CSS classes */
+  className?: string;
+
+  /** Whether to use compact spacing for forms */
+  compact?: boolean;
+}
 
 /**
  * A reusable Input component designed to match the established Apple-style
  * design system with glass-morphism effects, proper dark mode support,
  * and consistent styling across the application.
  */
-const Input = React.forwardRef(
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
   (
     {
       type = "text",
@@ -19,7 +57,7 @@ const Input = React.forwardRef(
       disabled = false,
       required = false,
       className = "",
-      compact = false, // Add compact prop
+      compact = false,
       ...props
     },
     ref
@@ -111,43 +149,6 @@ const Input = React.forwardRef(
   }
 );
 
-// CRITICAL: Add these lines at the end of your Input.jsx file
 Input.displayName = "Input";
-
-Input.propTypes = {
-  /** The input type (text, email, password, etc.) */
-  type: PropTypes.string,
-
-  /** The name attribute for the input */
-  name: PropTypes.string.isRequired,
-
-  /** Placeholder text */
-  placeholder: PropTypes.string,
-
-  /** Current input value */
-  value: PropTypes.string.isRequired,
-
-  /** Change handler function */
-  onChange: PropTypes.func.isRequired,
-
-  /** Optional label text displayed above the input */
-  label: PropTypes.string,
-
-  /** Error message to display below the input */
-  error: PropTypes.string,
-
-  /** Whether the input is disabled */
-  disabled: PropTypes.bool,
-
-  /** Whether the input is required */
-  required: PropTypes.bool,
-
-  /** Additional CSS classes */
-  className: PropTypes.string,
-
-  /** Whether to use compact spacing for forms */
-  compact: PropTypes.bool,
-};
-
 
 export default Input;

--- a/Frontend/EduLiteFrontend/tsconfig.json
+++ b/Frontend/EduLiteFrontend/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "allowJs": true,
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": false,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/Frontend/EduLiteFrontend/tsconfig.node.json
+++ b/Frontend/EduLiteFrontend/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true
+  },
+  "include": ["vite.config.js"]
+}

--- a/Frontend/README.md
+++ b/Frontend/README.md
@@ -5,69 +5,87 @@
 The EduLite frontend is a responsive interface that focuses on speed, clarity, and simplicity to make essential features easily accessible — such as courses , classes .It also supports multiple languages for ease and supports dark mode. The design avoids distractions to support a clear and smooth learning experience.
 
 
-## 🛠️ Tech
+## 🛠️ Tech Stack
 
-- HTML , CSS , Javascript
-- React JS
-- Tailwind CSS
-- Vite  (Fast and lightweight development server and build tool)
+- **TypeScript** - Type-safe JavaScript with enhanced IDE support
+- **React 19** - Latest React with improved performance
+- **Tailwind CSS v4** - Utility-first CSS framework
+- **Vite** - Lightning-fast build tool and dev server
+- **React Router v7** - Client-side routing
+- **i18next** - Internationalization support
 
 ## 🗂️ Project Structure
 
 ```
 Frontend/
-├──EduLiteFrontend/
-|     ├──node-modules/
-│     ├── public/
-│     │     └── vite.svg    #changed to EduLite logo
-│     ├── src/
-│     │   ├── assets/  # Images, logos, etc.
-│     │   │      ├── heroimg.png
-│     │   │      └── EduTech_Logo.webp
-│     │   │
-│     │   ├── components/
-│     │   │        ├── DarkModeToggle.jsx
-│     │   │        ├── Navbar.jsx
-│     │   │        ├── LanguageSwitcher.jsx
-│     │   │        └── Sidebar.jsx
-│     │   │
-│     │   ├── pages/
-│     │   │     ├── Home.jsx
-│     │   │     ├── Notifications.jsx
-│     │   │     ├── LogInandLogOut.jsx
-│     │   │     └── Chats.jsx
-│     │   │
-│     │   ├── i18n/
-│     │   │     ├── locals/
-│     │   │     │      ├── ar.json
-│     │   │     │      └── en.json
-│     │   │     └── index.js
-│     │   │
-│     │   ├── App.css
-│     │   ├── App.jsx
-│     │   ├── index.css
-│     ├── public/
-│     ├── src/
-│     │   ├── assets/  # Images, logos, etc.
-│     │   ├── components/
-│     │   ├── App.jsx
-│     │   └── main.jsx
-│     │
-│     ├── .gitignore
-│     ├── index.html
-│     ├── package.json
-│     ├── package-lock.json
-│     └── vite.config.js
-└──README.md
+├── EduLiteFrontend/
+│   ├── node_modules/
+│   ├── public/
+│   │   └── vite.svg    # EduLite logo
+│   ├── src/
+│   │   ├── assets/     # Images, logos, etc.
+│   │   │   ├── heroimg.png
+│   │   │   └── EduTech_Logo.webp
+│   │   │
+│   │   ├── components/
+│   │   │   ├── common/
+│   │   │   │   ├── Button.tsx  ✅ (TypeScript)
+│   │   │   │   └── Input.tsx   ✅ (TypeScript)
+│   │   │   ├── DarkModeToggle.jsx
+│   │   │   ├── Navbar.jsx
+│   │   │   ├── LanguageSwitcher.jsx
+│   │   │   └── Sidebar.jsx
+│   │   │
+│   │   ├── pages/
+│   │   │   ├── Home.jsx
+│   │   │   ├── Notifications.jsx
+│   │   │   ├── LogInandLogOut.jsx
+│   │   │   └── Chats.jsx
+│   │   │
+│   │   ├── i18n/
+│   │   │   ├── locals/
+│   │   │   │   ├── ar.json
+│   │   │   │   └── en.json
+│   │   │   └── index.js
+│   │   │
+│   │   ├── App.css
+│   │   ├── App.jsx
+│   │   ├── index.css
+│   │   └── main.jsx
+│   │
+│   ├── .gitignore
+│   ├── index.html
+│   ├── package.json
+│   ├── package-lock.json
+│   ├── tsconfig.json      # TypeScript config
+│   ├── tsconfig.node.json  # TypeScript Node config
+│   └── vite.config.js
+└── README.md
 ```
 ## 🚀 Getting Started
 
 ```bash
-
 cd Frontend/EduLiteFrontend
 npm install
 npm run dev
 ```
+
+## 📦 Available Scripts
+
+| Script | Command | Description |
+| ------ | ------- | ----------- |
+| `dev` | `npm run dev` | Start development server |
+| `build` | `npm run build` | Build for production |
+| `preview` | `npm run preview` | Preview production build |
+| `lint` | `npm run lint` | Run ESLint |
+| `type-check` | `npm run type-check` | Check TypeScript types |
+
+## ⚙️ TypeScript Configuration
+
+- **Strict Mode**: Full type safety enabled
+- **Path Aliases**: `@/*` maps to `src/*`
+- **Target**: ES2020 with modern browser support
+- **JSX**: React 19 automatic runtime
 
 ## 🗺️ Available Pages & Routing
 
@@ -82,7 +100,18 @@ these routs are defined in `src/App.jsx` using `react-router-dom` library.
 
 ## ✨ Component Showcase
 
-| Component | Description  | Demo Page |
-| --------- | ------------ | --------- |
-| `Button`  | A versatile button with multiple styles and sizes. | `/button-demo` |
-| `Input`   | An Apple-style input field for forms. | `/input-demo` |
+### TypeScript Components (Migrated)
+
+| Component | Type | Description | Props |
+| --------- | ---- | ----------- | ----- |
+| `Button` | `.tsx` | Versatile button with multiple styles | `type`, `size`, `width`, `disabled` |
+| `Input` | `.tsx` | Apple-style glass-morphism input | `label`, `error`, `compact`, `required` |
+
+### JavaScript Components (To be migrated)
+
+| Component | Status | Description |
+| --------- | ------ | ----------- |
+| `Navbar` | `.jsx` | Navigation bar component |
+| `Sidebar` | `.jsx` | Collapsible sidebar |
+| `DarkModeToggle` | `.jsx` | Theme switcher |
+| `LanguageSwitcher` | `.jsx` | i18n language selector |


### PR DESCRIPTION
# TypeScript Setup + Component Migration

Got the TypeScript foundation set up and migrated our first two components as examples for everyone else.

## What's New
- TypeScript config with strict mode (because we like our types safe)
- Button & Input components now fully typed
- Proper interfaces with good docs
- `npm run type-check` script added

## The Good Stuff
Both components keep the exact same functionality but now have:
- Type-safe props with IntelliSense
- Proper forwardRef support
- No more PropTypes (TypeScript handles it now)

## For Future Migrations
These components are solid examples of how to migrate - just follow the same pattern. The `allowJs: true` config means all existing `.jsx` files keep working while we gradually migrate.

## Testing
- ✅ `npm run dev` - works perfect
- ✅ `npm run type-check` - no errors
- ✅ All components render like before

Should be ready to merge!