### PR TITLE
fix: position toaster at bottom-left to prevent overlaying nav menu

### DIFF
--- a/Frontend/EduLiteFrontend/src/App.jsx
+++ b/Frontend/EduLiteFrontend/src/App.jsx
@@ -55,7 +55,7 @@ const AppContent = () => {
 
       {/* Toast notifications for login/logout feedback */}
       <Toaster
-        position="top-right"
+        position="bottom-left"
         toastOptions={{
           duration: 4000,
           style: {


### PR DESCRIPTION
## Description
Fixed Toaster's position from top-right to bottom-left.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] Manually reviewed the change

## Related Issues
Issue #165 
