### PR TITLE
175 tests add vitest testing framework to frontend

### DIFF
--- a/Frontend/EduLiteFrontend/package-lock.json
+++ b/Frontend/EduLiteFrontend/package-lock.json
@@ -24,17 +24,29 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
+        "@testing-library/jest-dom": "^6.8.0",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24.5.2",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^4.4.1",
+        "@vitest/ui": "^3.2.4",
         "eslint": "^9.25.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^16.0.0",
+        "jsdom": "^24.1.3",
         "typescript": "^5.9.2",
-        "vite": "^6.3.5"
+        "vite": "^6.3.5",
+        "vitest": "^3.2.4"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -48,6 +60,25 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -338,6 +369,116 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1039,6 +1180,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.40.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.40.2.tgz",
@@ -1561,6 +1708,98 @@
         "vite": "^5.2.0 || ^6"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.8.0.tgz",
+      "integrity": "sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ==",
+      "dev": true,
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1605,6 +1844,21 @@
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.7",
@@ -1668,6 +1922,135 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/ui": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.2.4.tgz",
+      "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "fflate": "^0.8.2",
+        "flatted": "^3.3.3",
+        "pathe": "^2.0.3",
+        "sirv": "^3.0.1",
+        "tinyglobby": "^0.2.14",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "3.2.4"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -1705,6 +2088,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1720,6 +2112,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -1744,6 +2146,24 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -1844,6 +2264,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -1905,6 +2334,22 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1920,6 +2365,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chownr": {
@@ -2049,11 +2503,49 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -2071,6 +2563,21 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -2099,6 +2606,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -2107,6 +2623,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2159,6 +2682,18 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -2176,6 +2711,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -2444,6 +2985,15 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2485,6 +3035,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -2582,6 +3141,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -2901,6 +3466,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
@@ -2925,6 +3502,32 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/i18next": {
@@ -3008,6 +3611,15 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -3047,6 +3659,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true
     },
     "node_modules/is-promise": {
       "version": "4.0.0",
@@ -3088,6 +3706,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "dev": true,
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -3424,6 +4082,12 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3441,6 +4105,16 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -3507,6 +4181,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3554,6 +4237,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -3604,6 +4296,12 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.22",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
+      "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
+      "dev": true
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -3713,6 +4411,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -3751,6 +4461,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -3818,6 +4543,41 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -3849,6 +4609,18 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3874,6 +4646,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -4037,6 +4815,25 @@
         "node": ">=18"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -4103,6 +4900,12 @@
         "node": ">= 18"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -4130,6 +4933,18 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.26.0",
@@ -4298,6 +5113,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4307,6 +5142,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -4315,6 +5156,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -4330,6 +5189,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -4342,6 +5219,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
     },
     "node_modules/tailwindcss": {
       "version": "4.1.7",
@@ -4384,6 +5267,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -4399,6 +5294,33 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -4407,6 +5329,42 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/type-check": {
@@ -4455,6 +5413,15 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
       "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
       "devOptional": true
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -4505,6 +5472,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/vary": {
@@ -4591,6 +5568,100 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/void-elements": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
@@ -4598,6 +5669,61 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -4616,6 +5742,22 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -4632,6 +5774,42 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/Frontend/EduLiteFrontend/package.json
+++ b/Frontend/EduLiteFrontend/package.json
@@ -9,7 +9,11 @@
     "copy-choices": "cp -r ../../project_choices_data public/",
     "lint": "eslint .",
     "preview": "vite preview",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "vitest",
+    "test:watch": "vitest --watch",
+    "test:ui": "vitest --ui",
+    "test:coverage": "vitest --coverage"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.7",
@@ -27,16 +31,22 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
+    "@testing-library/jest-dom": "^6.8.0",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.5.2",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",
+    "@vitest/ui": "^3.2.4",
     "eslint": "^9.25.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
+    "jsdom": "^24.1.3",
     "typescript": "^5.9.2",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^3.2.4"
   },
   "description": "This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.",
   "main": "eslint.config.js",

--- a/Frontend/EduLiteFrontend/src/components/common/__tests__/Button.edge.test.tsx
+++ b/Frontend/EduLiteFrontend/src/components/common/__tests__/Button.edge.test.tsx
@@ -1,0 +1,329 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders, screen, waitFor } from '@/test/utils';
+import userEvent from '@testing-library/user-event';
+import Button from '../Button';
+
+describe('Button Component - Edge Cases & Security', () => {
+  describe('Invalid Props - Fallback Behavior', () => {
+    it('falls back to primary type when given invalid type', () => {
+      // @ts-expect-error - Testing invalid prop value
+      renderWithProviders(<Button type="invalid-type">Button</Button>);
+      const button = screen.getByRole('button');
+      // Should fall back to primary styles
+      expect(button).toHaveClass('bg-blue-600', 'text-white');
+    });
+
+    it('falls back to medium size when given invalid size', () => {
+      // @ts-expect-error - Testing invalid prop value
+      renderWithProviders(<Button size="invalid-size">Button</Button>);
+      const button = screen.getByRole('button');
+      // Should fall back to medium size
+      expect(button).toHaveClass('px-4', 'py-2', 'text-base');
+    });
+
+    it('falls back to auto width when given invalid width', () => {
+      // @ts-expect-error - Testing invalid prop value
+      renderWithProviders(<Button width="invalid-width">Button</Button>);
+      const button = screen.getByRole('button');
+      // Should fall back to auto width
+      expect(button).toHaveClass('w-auto');
+    });
+  });
+
+  describe('Children Edge Cases', () => {
+    it('renders with empty string children', () => {
+      renderWithProviders(<Button>{''}</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toBeInTheDocument();
+      expect(button.textContent).toBe('');
+    });
+
+    it('renders with null children', () => {
+      renderWithProviders(<Button>{null}</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toBeInTheDocument();
+      expect(button.textContent).toBe('');
+    });
+
+    it('renders with undefined children', () => {
+      renderWithProviders(<Button>{undefined}</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toBeInTheDocument();
+      expect(button.textContent).toBe('');
+    });
+
+    it('renders with number as children', () => {
+      renderWithProviders(<Button>{0}</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveTextContent('0');
+    });
+
+    it('renders with React fragment children', () => {
+      renderWithProviders(
+        <Button>
+          <>
+            <span>Part 1</span>
+            <span>Part 2</span>
+          </>
+        </Button>
+      );
+      const button = screen.getByRole('button');
+      expect(button).toHaveTextContent('Part 1Part 2');
+    });
+
+    it('renders with JSX element children', () => {
+      renderWithProviders(
+        <Button>
+          <span data-testid="icon">🔥</span>
+          <span>Text</span>
+        </Button>
+      );
+      const button = screen.getByRole('button');
+      expect(button).toContainElement(screen.getByTestId('icon'));
+      expect(button).toHaveTextContent('🔥Text');
+    });
+  });
+
+  describe('ClassName Handling', () => {
+    it('applies custom className alongside default classes', () => {
+      renderWithProviders(<Button className="custom-class">Button</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('custom-class');
+      expect(button).toHaveClass('cursor-pointer'); // Still has base classes
+    });
+
+    it('handles empty string className', () => {
+      renderWithProviders(<Button className="">Button</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('cursor-pointer'); // Base classes still applied
+    });
+
+    it('handles multiple space-separated classes in className', () => {
+      renderWithProviders(<Button className="class1 class2 class3">Button</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('class1', 'class2', 'class3');
+    });
+
+    it('does not break with special characters in className', () => {
+      renderWithProviders(<Button className="bg-[#ff0000]">Button</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('bg-[#ff0000]');
+    });
+  });
+
+  describe('Async onClick Handlers', () => {
+    it('handles async onClick function', async () => {
+      const asyncClick = vi.fn(async () => {
+        await new Promise(resolve => setTimeout(resolve, 10));
+        return 'done';
+      });
+      const user = userEvent.setup();
+
+      renderWithProviders(<Button onClick={asyncClick}>Async Button</Button>);
+      const button = screen.getByRole('button');
+
+      await user.click(button);
+
+      expect(asyncClick).toHaveBeenCalledTimes(1);
+    });
+
+
+    it('handles onClick with Promise rejection', async () => {
+      const rejectClick = vi.fn(async () => {
+        throw new Error('Promise rejected');
+      });
+      const user = userEvent.setup();
+
+      renderWithProviders(<Button onClick={rejectClick}>Reject Button</Button>);
+      const button = screen.getByRole('button');
+
+      await user.click(button);
+      expect(rejectClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Rapid Clicking - Race Conditions', () => {
+    it('calls onClick for each rapid click', async () => {
+      const handleClick = vi.fn();
+      const user = userEvent.setup();
+
+      renderWithProviders(<Button onClick={handleClick}>Rapid Click</Button>);
+      const button = screen.getByRole('button');
+
+      // Rapid fire 10 clicks
+      await user.tripleClick(button);
+      await user.tripleClick(button);
+      await user.click(button);
+
+      // Should have been called multiple times
+      expect(handleClick.mock.calls.length).toBeGreaterThan(5);
+    });
+
+    it('disabled button prevents all rapid clicks', async () => {
+      const handleClick = vi.fn();
+      const user = userEvent.setup();
+
+      renderWithProviders(<Button disabled onClick={handleClick}>Disabled</Button>);
+      const button = screen.getByRole('button');
+
+      // Try rapid clicking disabled button
+      await user.tripleClick(button);
+      await user.tripleClick(button);
+
+      expect(handleClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Event Object Handling', () => {
+    it('passes event object to onClick handler', async () => {
+      const handleClick = vi.fn();
+      const user = userEvent.setup();
+
+      renderWithProviders(<Button onClick={handleClick}>Event Test</Button>);
+      const button = screen.getByRole('button');
+
+      await user.click(button);
+
+      expect(handleClick).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'click',
+          target: expect.any(Object),
+        })
+      );
+    });
+
+    it('event.preventDefault() can be called in onClick', async () => {
+      const handleClick = vi.fn((e) => {
+        e.preventDefault();
+      });
+      const user = userEvent.setup();
+
+      renderWithProviders(<Button onClick={handleClick}>Prevent Default</Button>);
+      const button = screen.getByRole('button');
+
+      await user.click(button);
+
+      expect(handleClick).toHaveBeenCalled();
+      // Should not throw error when preventDefault is called
+    });
+  });
+
+  describe('Button State Transitions', () => {
+    it('can transition from enabled to disabled', async () => {
+      const TestComponent = () => {
+        const [disabled, setDisabled] = React.useState(false);
+        return (
+          <>
+            <Button disabled={disabled} onClick={() => {}}>Target Button</Button>
+            <button onClick={() => setDisabled(true)}>Toggle</button>
+          </>
+        );
+      };
+
+      const user = userEvent.setup();
+      renderWithProviders(<TestComponent />);
+
+      const targetButton = screen.getByText('Target Button');
+      expect(targetButton).not.toBeDisabled();
+
+      await user.click(screen.getByText('Toggle'));
+
+      expect(targetButton).toBeDisabled();
+    });
+  });
+
+  describe('Ref Edge Cases', () => {
+    it('handles ref being set to null', () => {
+      const ref = { current: null };
+
+      renderWithProviders(<Button ref={ref}>Button</Button>);
+
+      expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+
+      // Manually set ref to null (simulating unmount)
+      ref.current = null;
+      expect(ref.current).toBeNull();
+    });
+
+    it('can access button methods via ref', () => {
+      const ref = React.createRef<HTMLButtonElement>();
+
+      renderWithProviders(<Button ref={ref}>Button</Button>);
+
+      expect(ref.current?.click).toBeDefined();
+      expect(ref.current?.focus).toBeDefined();
+      expect(ref.current?.blur).toBeDefined();
+    });
+
+    it('programmatic click via ref triggers onClick', () => {
+      const handleClick = vi.fn();
+      const ref = React.createRef<HTMLButtonElement>();
+
+      renderWithProviders(<Button ref={ref} onClick={handleClick}>Button</Button>);
+
+      // Programmatically trigger click
+      ref.current?.click();
+
+      expect(handleClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('HTML Button Attributes Edge Cases', () => {
+    it('accepts form attribute', () => {
+      renderWithProviders(<Button form="my-form">Submit</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveAttribute('form', 'my-form');
+    });
+
+    it('accepts formAction attribute', () => {
+      renderWithProviders(<Button formAction="/submit">Submit</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveAttribute('formaction', '/submit');
+    });
+
+    it('accepts data attributes', () => {
+      renderWithProviders(
+        <Button data-testid="btn" data-analytics="click-event">
+          Button
+        </Button>
+      );
+      const button = screen.getByTestId('btn');
+      expect(button).toHaveAttribute('data-analytics', 'click-event');
+    });
+
+    it('handles tabIndex attribute', () => {
+      renderWithProviders(<Button tabIndex={-1}>No Tab</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveAttribute('tabindex', '-1');
+    });
+  });
+
+  describe('Accessibility Edge Cases', () => {
+    it('can have both aria-label and children', () => {
+      renderWithProviders(<Button aria-label="Close dialog">X</Button>);
+      const button = screen.getByRole('button', { name: /close dialog/i });
+      expect(button).toHaveTextContent('X');
+    });
+
+    it('handles aria-describedby', () => {
+      renderWithProviders(
+        <>
+          <Button aria-describedby="help-text">Submit</Button>
+          <p id="help-text">This will submit the form</p>
+        </>
+      );
+      const button = screen.getByRole('button');
+      expect(button).toHaveAttribute('aria-describedby', 'help-text');
+    });
+
+    it('handles role override', () => {
+      renderWithProviders(<Button role="link">Link Button</Button>);
+      // Still renders as button element, but with link role
+      const element = screen.getByRole('link');
+      expect(element.tagName).toBe('BUTTON');
+    });
+  });
+});
+
+// Need to import React for useState in tests
+import React from 'react';

--- a/Frontend/EduLiteFrontend/src/components/common/__tests__/Button.edge.test.tsx
+++ b/Frontend/EduLiteFrontend/src/components/common/__tests__/Button.edge.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { renderWithProviders, screen, waitFor } from '@/test/utils';
+import { renderWithProviders, screen } from '@/test/utils';
 import userEvent from '@testing-library/user-event';
 import Button from '../Button';
 

--- a/Frontend/EduLiteFrontend/src/components/common/__tests__/Button.test.tsx
+++ b/Frontend/EduLiteFrontend/src/components/common/__tests__/Button.test.tsx
@@ -207,7 +207,7 @@ describe('Button Component', () => {
       renderWithProviders(<Button ref={ref}>Button with Ref</Button>);
 
       expect(ref.current).toBeInstanceOf(HTMLButtonElement);
-      expect(ref.current?.textContent).toBe('Button with Ref');
+      expect((ref.current as unknown as HTMLButtonElement)?.textContent).toBe('Button with Ref');
     });
   });
 

--- a/Frontend/EduLiteFrontend/src/components/common/__tests__/Button.test.tsx
+++ b/Frontend/EduLiteFrontend/src/components/common/__tests__/Button.test.tsx
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders, screen } from '@/test/utils';
+import userEvent from '@testing-library/user-event';
+import Button from '../Button';
+
+describe('Button Component', () => {
+  describe('Rendering', () => {
+    it('renders with children text', () => {
+      renderWithProviders(<Button>Click me</Button>);
+      expect(screen.getByRole('button', { name: /click me/i })).toBeInTheDocument();
+    });
+
+    it('renders with default primary type', () => {
+      renderWithProviders(<Button>Primary Button</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('bg-blue-600');
+    });
+
+    it('renders with custom className', () => {
+      renderWithProviders(<Button className="custom-class">Button</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('custom-class');
+    });
+  });
+
+  describe('Type Variants', () => {
+    it('renders primary variant correctly', () => {
+      renderWithProviders(<Button type="primary">Primary</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('bg-blue-600', 'text-white');
+    });
+
+    it('renders secondary variant correctly', () => {
+      renderWithProviders(<Button type="secondary">Secondary</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('bg-white', 'text-blue-700', 'border', 'border-blue-600');
+    });
+
+    it('renders danger variant correctly', () => {
+      renderWithProviders(<Button type="danger">Delete</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('bg-red-600', 'text-white');
+    });
+  });
+
+  describe('Size Variants', () => {
+    it('renders small size correctly', () => {
+      renderWithProviders(<Button size="sm">Small</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('px-3', 'py-1.5', 'text-sm');
+    });
+
+    it('renders medium size correctly (default)', () => {
+      renderWithProviders(<Button size="md">Medium</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('px-4', 'py-2', 'text-base');
+    });
+
+    it('renders large size correctly', () => {
+      renderWithProviders(<Button size="lg">Large</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('px-6', 'py-3', 'text-lg');
+    });
+  });
+
+  describe('Width Variants', () => {
+    it('renders auto width (default)', () => {
+      renderWithProviders(<Button>Auto Width</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('w-auto');
+    });
+
+    it('renders full width', () => {
+      renderWithProviders(<Button width="full">Full Width</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('w-full');
+    });
+
+    it('renders half width', () => {
+      renderWithProviders(<Button width="half">Half Width</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('w-1/2');
+    });
+
+    it('renders one-third width', () => {
+      renderWithProviders(<Button width="one-third">One Third</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('w-1/3');
+    });
+  });
+
+  describe('Disabled State', () => {
+    it('renders disabled button correctly', () => {
+      renderWithProviders(<Button disabled>Disabled</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toBeDisabled();
+      expect(button).toHaveClass('disabled:opacity-50', 'disabled:cursor-not-allowed');
+      expect(button).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('does not call onClick when disabled', async () => {
+      const handleClick = vi.fn();
+      const user = userEvent.setup();
+
+      renderWithProviders(<Button disabled onClick={handleClick}>Disabled</Button>);
+      const button = screen.getByRole('button');
+
+      await user.click(button);
+      expect(handleClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Click Handler', () => {
+    it('calls onClick when button is clicked', async () => {
+      const handleClick = vi.fn();
+      const user = userEvent.setup();
+
+      renderWithProviders(<Button onClick={handleClick}>Click Me</Button>);
+      const button = screen.getByRole('button');
+
+      await user.click(button);
+      expect(handleClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClick multiple times', async () => {
+      const handleClick = vi.fn();
+      const user = userEvent.setup();
+
+      renderWithProviders(<Button onClick={handleClick}>Click Me</Button>);
+      const button = screen.getByRole('button');
+
+      await user.click(button);
+      await user.click(button);
+      await user.click(button);
+
+      expect(handleClick).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('has button role', () => {
+      renderWithProviders(<Button>Button</Button>);
+      expect(screen.getByRole('button')).toBeInTheDocument();
+    });
+
+    it('has proper type attribute', () => {
+      renderWithProviders(<Button>Button</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveAttribute('type', 'button');
+    });
+
+    it('supports aria-label', () => {
+      renderWithProviders(<Button aria-label="Close modal">×</Button>);
+      const button = screen.getByRole('button', { name: /close modal/i });
+      expect(button).toBeInTheDocument();
+    });
+
+    it('has focus styles', () => {
+      renderWithProviders(<Button>Focus Me</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('focus:outline-none', 'focus-visible:ring-2');
+    });
+  });
+
+  describe('Keyboard Navigation', () => {
+    it('can be focused with keyboard', async () => {
+      const user = userEvent.setup();
+
+      renderWithProviders(<Button>Keyboard Button</Button>);
+      const button = screen.getByRole('button');
+
+      await user.tab();
+      expect(button).toHaveFocus();
+    });
+
+    it('can be activated with Enter key', async () => {
+      const handleClick = vi.fn();
+      const user = userEvent.setup();
+
+      renderWithProviders(<Button onClick={handleClick}>Press Enter</Button>);
+      const button = screen.getByRole('button');
+
+      button.focus();
+      await user.keyboard('{Enter}');
+
+      expect(handleClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('can be activated with Space key', async () => {
+      const handleClick = vi.fn();
+      const user = userEvent.setup();
+
+      renderWithProviders(<Button onClick={handleClick}>Press Space</Button>);
+      const button = screen.getByRole('button');
+
+      button.focus();
+      await user.keyboard(' ');
+
+      expect(handleClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Forward Ref', () => {
+    it('forwards ref to button element', () => {
+      const ref = { current: null };
+
+      renderWithProviders(<Button ref={ref}>Button with Ref</Button>);
+
+      expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+      expect(ref.current?.textContent).toBe('Button with Ref');
+    });
+  });
+
+  describe('HTML Button Attributes', () => {
+    it('accepts and applies additional HTML button attributes', () => {
+      renderWithProviders(
+        <Button data-testid="custom-button" title="Custom title">
+          Button
+        </Button>
+      );
+
+      const button = screen.getByTestId('custom-button');
+      expect(button).toHaveAttribute('title', 'Custom title');
+    });
+  });
+});

--- a/Frontend/EduLiteFrontend/src/components/common/__tests__/Input.edge.test.tsx
+++ b/Frontend/EduLiteFrontend/src/components/common/__tests__/Input.edge.test.tsx
@@ -65,7 +65,7 @@ describe('Input Component - Edge Cases & Security', () => {
 
       const input = screen.getByPlaceholderText(/<img src=x onerror=alert\(1\)>/i);
       expect(input).toBeInTheDocument();
-      expect(input.placeholder).toBe('<img src=x onerror=alert(1)>');
+      expect((input as HTMLInputElement).placeholder).toBe('<img src=x onerror=alert(1)>');
     });
   });
 
@@ -407,7 +407,6 @@ describe('Input Component - Edge Cases & Security', () => {
       );
 
       // Empty error should not render the error paragraph
-      const input = screen.getByRole('textbox');
       const errorElements = document.querySelectorAll('.text-red-600');
 
       // Only label should have red color if error prop exists, but empty error shouldn't render <p>

--- a/Frontend/EduLiteFrontend/src/components/common/__tests__/Input.edge.test.tsx
+++ b/Frontend/EduLiteFrontend/src/components/common/__tests__/Input.edge.test.tsx
@@ -1,0 +1,565 @@
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { renderWithProviders, screen, waitFor } from '@/test/utils';
+import userEvent from '@testing-library/user-event';
+import Input from '../Input';
+
+describe('Input Component - Edge Cases & Security', () => {
+  describe('XSS Security Tests', () => {
+    it('escapes HTML in error messages', () => {
+      const xssAttempt = '<script>alert("XSS")</script>';
+      renderWithProviders(
+        <Input
+          name="test"
+          value=""
+          onChange={() => {}}
+          error={xssAttempt}
+        />
+      );
+
+      // Error text should be escaped, not executed
+      const errorElement = screen.getByText(/<script>alert\("XSS"\)<\/script>/i);
+      expect(errorElement).toBeInTheDocument();
+      expect(errorElement.innerHTML).not.toContain('<script');
+    });
+
+    it('escapes HTML entities in error messages', () => {
+      renderWithProviders(
+        <Input
+          name="test"
+          value=""
+          onChange={() => {}}
+          error="<img src=x onerror=alert(1)>"
+        />
+      );
+
+      const errorElement = screen.getByText(/<img src=x onerror=alert\(1\)>/i);
+      expect(errorElement).toBeInTheDocument();
+      // Should be text content, not actual HTML
+      expect(errorElement.querySelector('img')).toBeNull();
+    });
+
+    it('escapes HTML in label text', () => {
+      renderWithProviders(
+        <Input
+          name="test"
+          label="<script>alert('xss')</script>"
+          value=""
+          onChange={() => {}}
+        />
+      );
+
+      const label = screen.getByText(/<script>alert\('xss'\)<\/script>/i);
+      expect(label).toBeInTheDocument();
+    });
+
+    it('handles malicious placeholder text safely', () => {
+      renderWithProviders(
+        <Input
+          name="test"
+          placeholder="<img src=x onerror=alert(1)>"
+          value=""
+          onChange={() => {}}
+        />
+      );
+
+      const input = screen.getByPlaceholderText(/<img src=x onerror=alert\(1\)>/i);
+      expect(input).toBeInTheDocument();
+      expect(input.placeholder).toBe('<img src=x onerror=alert(1)>');
+    });
+  });
+
+  describe('Value Edge Cases', () => {
+    it('handles empty string value', () => {
+      renderWithProviders(
+        <Input name="test" value="" onChange={() => {}} />
+      );
+      const input = screen.getByRole('textbox');
+      expect(input).toHaveValue('');
+    });
+
+    it('handles very long text value (10k characters)', () => {
+      const longValue = 'a'.repeat(10000);
+      renderWithProviders(
+        <Input name="test" value={longValue} onChange={() => {}} />
+      );
+      const input = screen.getByRole('textbox');
+      expect(input).toHaveValue(longValue);
+      expect((input as HTMLInputElement).value.length).toBe(10000);
+    });
+
+    it('handles Unicode and emoji values', () => {
+      const unicodeValue = '🔥💯✨🎉 Hello 世界 مرحبا';
+      renderWithProviders(
+        <Input name="test" value={unicodeValue} onChange={() => {}} />
+      );
+      const input = screen.getByRole('textbox');
+      expect(input).toHaveValue(unicodeValue);
+    });
+
+    it('handles special characters', () => {
+      const specialChars = '!@#$%^&*()_+-={}[]|\\:";\'<>?,./`~';
+      renderWithProviders(
+        <Input name="test" value={specialChars} onChange={() => {}} />
+      );
+      const input = screen.getByRole('textbox');
+      expect(input).toHaveValue(specialChars);
+    });
+
+    it('handles newlines and tabs in value', () => {
+      const multilineValue = 'Line 1\nLine 2\tTabbed';
+      renderWithProviders(
+        <Input name="test" value={multilineValue} onChange={() => {}} />
+      );
+      const input = screen.getByRole('textbox');
+      // Browser <input> elements strip newlines - this is expected behavior
+      expect(input).toHaveValue('Line 1Line 2\tTabbed');
+    });
+
+    it('handles null-like string values', () => {
+      renderWithProviders(
+        <Input name="test" value="null" onChange={() => {}} />
+      );
+      const input = screen.getByRole('textbox');
+      expect(input).toHaveValue('null');
+    });
+  });
+
+  describe('Rapid Typing Performance', () => {
+    it('handles rapid typing without dropping characters', async () => {
+      const handleChange = vi.fn();
+      const user = userEvent.setup({ delay: null }); // No delay for fast typing
+
+      const TestComponent = () => {
+        const [value, setValue] = React.useState('');
+        return (
+          <Input
+            name="test"
+            value={value}
+            onChange={(e) => {
+              handleChange(e);
+              setValue(e.target.value);
+            }}
+          />
+        );
+      };
+
+      renderWithProviders(<TestComponent />);
+      const input = screen.getByRole('textbox');
+
+      // Type rapidly
+      await user.type(input, 'RapidTyping123!');
+
+      // Final value should be correct (most important)
+      expect(input).toHaveValue('RapidTyping123!');
+      // React may batch some onChange calls, so we check it was called at least once
+      // and not more than the character count
+      expect(handleChange.mock.calls.length).toBeGreaterThan(0);
+      expect(handleChange.mock.calls.length).toBeLessThanOrEqual(16);
+    });
+
+    it('handles 100+ character rapid input', async () => {
+      const longText = 'a'.repeat(100);
+      const user = userEvent.setup({ delay: null });
+
+      const TestComponent = () => {
+        const [value, setValue] = React.useState('');
+        return (
+          <Input
+            name="test"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+          />
+        );
+      };
+
+      renderWithProviders(<TestComponent />);
+      const input = screen.getByRole('textbox');
+
+      await user.type(input, longText);
+
+      expect((input as HTMLInputElement).value.length).toBe(100);
+    });
+  });
+
+  describe('Paste Operations', () => {
+    it('handles paste with large text', async () => {
+      const largeText = 'Lorem ipsum '.repeat(1000); // ~12,000 characters
+      const user = userEvent.setup();
+
+      const TestComponent = () => {
+        const [value, setValue] = React.useState('');
+        return (
+          <Input
+            name="test"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+          />
+        );
+      };
+
+      renderWithProviders(<TestComponent />);
+      const input = screen.getByRole('textbox');
+
+      await user.click(input);
+      await user.paste(largeText);
+
+      expect(input).toHaveValue(largeText);
+    });
+
+    it('handles paste with special characters', async () => {
+      const specialText = '<script>alert("xss")</script>\n\ttab\n©™®';
+      const user = userEvent.setup();
+
+      const TestComponent = () => {
+        const [value, setValue] = React.useState('');
+        return (
+          <Input
+            name="test"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+          />
+        );
+      };
+
+      renderWithProviders(<TestComponent />);
+      const input = screen.getByRole('textbox');
+
+      await user.click(input);
+      await user.paste(specialText);
+
+      // Browser <input> elements strip newlines - expect normalized value
+      expect(input).toHaveValue('<script>alert("xss")</script>\ttab©™®');
+    });
+
+    it('handles paste into input with existing value', async () => {
+      const user = userEvent.setup();
+
+      const TestComponent = () => {
+        const [value, setValue] = React.useState('existing');
+        return (
+          <Input
+            name="test"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+          />
+        );
+      };
+
+      renderWithProviders(<TestComponent />);
+      const input = screen.getByRole('textbox');
+
+      // Select all and paste over
+      await user.click(input);
+      await user.keyboard('{Control>}a{/Control}');
+      await user.paste('pasted');
+
+      expect(input).toHaveValue('pasted');
+    });
+  });
+
+  describe('ClassName Border-Red Logic Bug (Line 101)', () => {
+    it('handles className with border-red correctly', () => {
+      renderWithProviders(
+        <Input
+          name="test"
+          value=""
+          onChange={() => {}}
+          className="border-red-600"
+        />
+      );
+
+      const container = document.querySelector('.border-red-600');
+      expect(container).toBeInTheDocument();
+    });
+
+    it('error prop takes precedence over className border', () => {
+      renderWithProviders(
+        <Input
+          name="test"
+          value=""
+          onChange={() => {}}
+          className="border-blue-500"
+          error="Error message"
+        />
+      );
+
+      const input = screen.getByRole('textbox');
+      // Error styling should apply
+      expect(input).toHaveClass('border-red-500/50');
+    });
+
+    it('handles both error and className with border-red', () => {
+      renderWithProviders(
+        <Input
+          name="test"
+          value=""
+          onChange={() => {}}
+          className="border-red-900"
+          error="Error"
+        />
+      );
+
+      const input = screen.getByRole('textbox');
+      // Error border should win
+      expect(input).toHaveClass('border-red-500/50');
+    });
+  });
+
+  describe('Focus Management Edge Cases', () => {
+    it('handles rapid focus and blur', async () => {
+      const ref = React.createRef<HTMLInputElement>();
+
+      renderWithProviders(
+        <Input ref={ref} name="test" value="" onChange={() => {}} />
+      );
+
+      // Rapidly focus and blur
+      ref.current?.focus();
+      ref.current?.blur();
+      ref.current?.focus();
+      ref.current?.blur();
+      ref.current?.focus();
+
+      await waitFor(() => {
+        expect(ref.current).toHaveFocus();
+      });
+    });
+
+    it('can focus input programmatically twice', () => {
+      const ref = React.createRef<HTMLInputElement>();
+
+      renderWithProviders(
+        <Input ref={ref} name="test" value="" onChange={() => {}} />
+      );
+
+      ref.current?.focus();
+      expect(ref.current).toHaveFocus();
+
+      ref.current?.blur();
+      expect(ref.current).not.toHaveFocus();
+
+      ref.current?.focus();
+      expect(ref.current).toHaveFocus();
+    });
+
+    it('disabled input cannot be focused programmatically', () => {
+      const ref = React.createRef<HTMLInputElement>();
+
+      renderWithProviders(
+        <Input ref={ref} name="test" value="" onChange={() => {}} disabled />
+      );
+
+      ref.current?.focus();
+      expect(ref.current).not.toHaveFocus();
+    });
+  });
+
+  describe('Error State Edge Cases', () => {
+    it('handles error message changing dynamically', async () => {
+      const TestComponent = () => {
+        const [error, setError] = React.useState('First error');
+        return (
+          <>
+            <Input name="test" value="" onChange={() => {}} error={error} />
+            <button onClick={() => setError('Second error')}>Change Error</button>
+          </>
+        );
+      };
+
+      const user = userEvent.setup();
+      renderWithProviders(<TestComponent />);
+
+      expect(screen.getByText('First error')).toBeInTheDocument();
+
+      const button = screen.getByText('Change Error');
+      await user.click(button);
+
+      expect(screen.getByText('Second error')).toBeInTheDocument();
+      expect(screen.queryByText('First error')).not.toBeInTheDocument();
+    });
+
+    it('handles error being removed', async () => {
+      const TestComponent = () => {
+        const [error, setError] = React.useState<string | undefined>('Has error');
+        return (
+          <>
+            <Input name="test" value="" onChange={() => {}} error={error} />
+            <button onClick={() => setError(undefined)}>Clear Error</button>
+          </>
+        );
+      };
+
+      const user = userEvent.setup();
+      renderWithProviders(<TestComponent />);
+
+      expect(screen.getByText('Has error')).toBeInTheDocument();
+
+      const button = screen.getByText('Clear Error');
+      await user.click(button);
+
+      expect(screen.queryByText('Has error')).not.toBeInTheDocument();
+    });
+
+    it('handles empty string error (should not render)', () => {
+      renderWithProviders(
+        <Input name="test" value="" onChange={() => {}} error="" />
+      );
+
+      // Empty error should not render the error paragraph
+      const input = screen.getByRole('textbox');
+      const errorElements = document.querySelectorAll('.text-red-600');
+
+      // Only label should have red color if error prop exists, but empty error shouldn't render <p>
+      const errorParagraphs = Array.from(errorElements).filter(el => el.tagName === 'P');
+      expect(errorParagraphs.length).toBe(0);
+    });
+
+    it('handles very long error message', () => {
+      const longError = 'Error: ' + 'a'.repeat(500);
+      renderWithProviders(
+        <Input name="test" value="" onChange={() => {}} error={longError} />
+      );
+
+      expect(screen.getByText(new RegExp(longError))).toBeInTheDocument();
+    });
+  });
+
+  describe('onChange Edge Cases', () => {
+
+    it('handles async onChange', async () => {
+      const asyncOnChange = vi.fn(async () => {
+        await new Promise(resolve => setTimeout(resolve, 10));
+      });
+      const user = userEvent.setup();
+
+      renderWithProviders(
+        <Input name="test" value="" onChange={asyncOnChange} />
+      );
+      const input = screen.getByRole('textbox');
+
+      await user.type(input, 'test');
+      expect(asyncOnChange).toHaveBeenCalled();
+    });
+  });
+
+  describe('Required Field Edge Cases', () => {
+    it('can transition from required to optional', async () => {
+      const TestComponent = () => {
+        const [required, setRequired] = React.useState(true);
+        return (
+          <>
+            <Input
+              name="test"
+              label="Field"
+              value=""
+              onChange={() => {}}
+              required={required}
+            />
+            <button onClick={() => setRequired(false)}>Make Optional</button>
+          </>
+        );
+      };
+
+      const user = userEvent.setup();
+      renderWithProviders(<TestComponent />);
+
+      expect(screen.getByText('*')).toBeInTheDocument();
+
+      const button = screen.getByText('Make Optional');
+      await user.click(button);
+
+      expect(screen.queryByText('*')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Disabled State Transitions', () => {
+    it('can transition from enabled to disabled while preserving value', async () => {
+      const TestComponent = () => {
+        const [disabled, setDisabled] = React.useState(false);
+        const [value, setValue] = React.useState('test value');
+        return (
+          <>
+            <Input
+              name="test"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              disabled={disabled}
+            />
+            <button onClick={() => setDisabled(true)}>Disable</button>
+          </>
+        );
+      };
+
+      const user = userEvent.setup();
+      renderWithProviders(<TestComponent />);
+
+      const input = screen.getByRole('textbox');
+      expect(input).not.toBeDisabled();
+      expect(input).toHaveValue('test value');
+
+      const button = screen.getByText('Disable');
+      await user.click(button);
+
+      expect(input).toBeDisabled();
+      expect(input).toHaveValue('test value'); // Value preserved
+    });
+  });
+
+  describe('Compact Mode Edge Cases', () => {
+    it('transitions between compact and normal spacing', async () => {
+      const TestComponent = () => {
+        const [compact, setCompact] = React.useState(false);
+        return (
+          <>
+            <Input
+              name="test"
+              label="Test"
+              value=""
+              onChange={() => {}}
+              compact={compact}
+            />
+            <button onClick={() => setCompact(!compact)}>Toggle Compact</button>
+          </>
+        );
+      };
+
+      const user = userEvent.setup();
+      const { container } = renderWithProviders(<TestComponent />);
+
+      let wrapper = container.firstChild;
+      expect(wrapper).toHaveClass('mb-6');
+
+      const button = screen.getByText('Toggle Compact');
+      await user.click(button);
+
+      wrapper = container.firstChild;
+      expect(wrapper).toHaveClass('mb-3');
+    });
+  });
+
+  describe('Input Type Edge Cases', () => {
+    it('handles switching input types', async () => {
+      const TestComponent = () => {
+        const [type, setType] = React.useState('text');
+        return (
+          <>
+            <Input name="test" type={type} value="" onChange={() => {}} />
+            <button onClick={() => setType('password')}>To Password</button>
+          </>
+        );
+      };
+
+      const user = userEvent.setup();
+      renderWithProviders(<TestComponent />);
+
+      const input = document.querySelector('input[name="test"]');
+      expect(input).toHaveAttribute('type', 'text');
+
+      const button = screen.getByText('To Password');
+      await user.click(button);
+
+      expect(input).toHaveAttribute('type', 'password');
+    });
+  });
+});

--- a/Frontend/EduLiteFrontend/src/components/common/__tests__/Input.test.tsx
+++ b/Frontend/EduLiteFrontend/src/components/common/__tests__/Input.test.tsx
@@ -378,7 +378,7 @@ describe('Input Component', () => {
       );
 
       expect(ref.current).toBeInstanceOf(HTMLInputElement);
-      expect(ref.current?.name).toBe('ref-test');
+      expect((ref.current as unknown as HTMLInputElement)?.name).toBe('ref-test');
     });
 
     it('allows focus via ref', () => {
@@ -393,7 +393,7 @@ describe('Input Component', () => {
         />
       );
 
-      ref.current?.focus();
+      (ref.current as unknown as HTMLInputElement)?.focus();
       expect(ref.current).toHaveFocus();
     });
   });

--- a/Frontend/EduLiteFrontend/src/components/common/__tests__/Input.test.tsx
+++ b/Frontend/EduLiteFrontend/src/components/common/__tests__/Input.test.tsx
@@ -1,0 +1,431 @@
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { renderWithProviders, screen } from '@/test/utils';
+import userEvent from '@testing-library/user-event';
+import Input from '../Input';
+
+describe('Input Component', () => {
+  describe('Rendering', () => {
+    it('renders input field', () => {
+      renderWithProviders(
+        <Input
+          name="test-input"
+          value=""
+          onChange={() => {}}
+        />
+      );
+      const input = screen.getByRole('textbox');
+      expect(input).toBeInTheDocument();
+    });
+
+    it('renders with label', () => {
+      renderWithProviders(
+        <Input
+          name="email"
+          label="Email Address"
+          value=""
+          onChange={() => {}}
+        />
+      );
+      expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+      expect(screen.getByText(/email address/i)).toBeInTheDocument();
+    });
+
+    it('renders without label', () => {
+      renderWithProviders(
+        <Input
+          name="test"
+          value=""
+          onChange={() => {}}
+        />
+      );
+      const input = screen.getByRole('textbox');
+      expect(input).not.toHaveAccessibleName();
+    });
+
+    it('renders with placeholder', () => {
+      renderWithProviders(
+        <Input
+          name="test"
+          placeholder="Enter text here"
+          value=""
+          onChange={() => {}}
+        />
+      );
+      expect(screen.getByPlaceholderText(/enter text here/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('Input Types', () => {
+    it('renders text input by default', () => {
+      renderWithProviders(
+        <Input
+          name="text"
+          value=""
+          onChange={() => {}}
+        />
+      );
+      const input = screen.getByRole('textbox');
+      expect(input).toHaveAttribute('type', 'text');
+    });
+
+    it('renders email input', () => {
+      renderWithProviders(
+        <Input
+          name="email"
+          type="email"
+          value=""
+          onChange={() => {}}
+        />
+      );
+      const input = screen.getByRole('textbox');
+      expect(input).toHaveAttribute('type', 'email');
+    });
+
+    it('renders password input', () => {
+      renderWithProviders(
+        <Input
+          name="password"
+          type="password"
+          value=""
+          onChange={() => {}}
+        />
+      );
+      // Password inputs don't have a standard role, query by name attribute
+      const input = document.querySelector('input[name="password"]');
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveAttribute('type', 'password');
+    });
+
+    it('renders search input', () => {
+      renderWithProviders(
+        <Input
+          name="search"
+          type="search"
+          value=""
+          onChange={() => {}}
+        />
+      );
+      const input = screen.getByRole('searchbox');
+      expect(input).toHaveAttribute('type', 'search');
+    });
+  });
+
+  describe('Value and Change Handler', () => {
+    it('displays the provided value', () => {
+      renderWithProviders(
+        <Input
+          name="test"
+          value="Hello World"
+          onChange={() => {}}
+        />
+      );
+      const input = screen.getByRole('textbox');
+      expect(input).toHaveValue('Hello World');
+    });
+
+    it('calls onChange when user types', async () => {
+      const handleChange = vi.fn();
+      const user = userEvent.setup();
+
+      renderWithProviders(
+        <Input
+          name="test"
+          value=""
+          onChange={handleChange}
+        />
+      );
+      const input = screen.getByRole('textbox');
+
+      await user.type(input, 'Hello');
+
+      expect(handleChange).toHaveBeenCalled();
+      expect(handleChange).toHaveBeenCalledTimes(5); // Once per character
+    });
+
+    it('updates value on user input', async () => {
+      const TestComponent = () => {
+        const [value, setValue] = React.useState('');
+        return (
+          <Input
+            name="test"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+          />
+        );
+      };
+
+      const user = userEvent.setup();
+      renderWithProviders(<TestComponent />);
+      const input = screen.getByRole('textbox');
+
+      await user.type(input, 'Testing');
+
+      expect(input).toHaveValue('Testing');
+    });
+  });
+
+  describe('Required Field', () => {
+    it('renders required indicator when required prop is true', () => {
+      renderWithProviders(
+        <Input
+          name="required-field"
+          label="Required Field"
+          value=""
+          onChange={() => {}}
+          required
+        />
+      );
+      // Check for asterisk (*)
+      expect(screen.getByText('*')).toBeInTheDocument();
+    });
+
+    it('has required attribute when required prop is true', () => {
+      renderWithProviders(
+        <Input
+          name="test"
+          value=""
+          onChange={() => {}}
+          required
+        />
+      );
+      const input = screen.getByRole('textbox');
+      expect(input).toBeRequired();
+    });
+
+    it('does not show asterisk when required is false', () => {
+      renderWithProviders(
+        <Input
+          name="optional-field"
+          label="Optional Field"
+          value=""
+          onChange={() => {}}
+        />
+      );
+      expect(screen.queryByText('*')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Error State', () => {
+    it('displays error message when error prop is provided', () => {
+      renderWithProviders(
+        <Input
+          name="test"
+          value=""
+          onChange={() => {}}
+          error="This field is required"
+        />
+      );
+      expect(screen.getByText(/this field is required/i)).toBeInTheDocument();
+    });
+
+    it('applies error styling when error exists', () => {
+      renderWithProviders(
+        <Input
+          name="test"
+          label="Test"
+          value=""
+          onChange={() => {}}
+          error="Error message"
+        />
+      );
+      const input = screen.getByRole('textbox');
+      expect(input).toHaveClass('border-red-500/50');
+    });
+
+    it('applies error styling to label when error exists', () => {
+      renderWithProviders(
+        <Input
+          name="test"
+          label="Test Label"
+          value=""
+          onChange={() => {}}
+          error="Error message"
+        />
+      );
+      const label = screen.getByText(/test label/i);
+      expect(label).toHaveClass('text-red-600');
+    });
+
+    it('does not display error message when error prop is not provided', () => {
+      renderWithProviders(
+        <Input
+          name="test"
+          value=""
+          onChange={() => {}}
+        />
+      );
+      // Error messages should not be in the document
+      const errorElements = document.querySelectorAll('.text-red-600');
+      expect(errorElements.length).toBe(0);
+    });
+  });
+
+  describe('Disabled State', () => {
+    it('renders disabled input correctly', () => {
+      renderWithProviders(
+        <Input
+          name="test"
+          value=""
+          onChange={() => {}}
+          disabled
+        />
+      );
+      const input = screen.getByRole('textbox');
+      expect(input).toBeDisabled();
+    });
+
+    it('applies disabled styling', () => {
+      renderWithProviders(
+        <Input
+          name="test"
+          value=""
+          onChange={() => {}}
+          disabled
+        />
+      );
+      const input = screen.getByRole('textbox');
+      expect(input).toHaveClass('opacity-60', 'cursor-not-allowed');
+    });
+
+    it('does not call onChange when disabled', async () => {
+      const handleChange = vi.fn();
+      const user = userEvent.setup();
+
+      renderWithProviders(
+        <Input
+          name="test"
+          value=""
+          onChange={handleChange}
+          disabled
+        />
+      );
+      const input = screen.getByRole('textbox');
+
+      await user.type(input, 'test');
+
+      expect(handleChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Compact Mode', () => {
+    it('applies compact spacing when compact prop is true', () => {
+      const { container } = renderWithProviders(
+        <Input
+          name="test"
+          label="Compact"
+          value=""
+          onChange={() => {}}
+          compact
+        />
+      );
+      const wrapper = container.firstChild;
+      expect(wrapper).toHaveClass('mb-3');
+    });
+
+    it('applies normal spacing when compact prop is false', () => {
+      const { container } = renderWithProviders(
+        <Input
+          name="test"
+          label="Normal"
+          value=""
+          onChange={() => {}}
+        />
+      );
+      const wrapper = container.firstChild;
+      expect(wrapper).toHaveClass('mb-6');
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('associates label with input using htmlFor and id', () => {
+      renderWithProviders(
+        <Input
+          name="accessible-input"
+          label="Accessible Input"
+          value=""
+          onChange={() => {}}
+        />
+      );
+      const input = screen.getByLabelText(/accessible input/i);
+      expect(input).toHaveAttribute('id', 'accessible-input');
+    });
+
+    it('has proper name attribute', () => {
+      renderWithProviders(
+        <Input
+          name="test-name"
+          value=""
+          onChange={() => {}}
+        />
+      );
+      const input = screen.getByRole('textbox');
+      expect(input).toHaveAttribute('name', 'test-name');
+    });
+  });
+
+  describe('Forward Ref', () => {
+    it('forwards ref to input element', () => {
+      const ref = { current: null };
+
+      renderWithProviders(
+        <Input
+          ref={ref}
+          name="ref-test"
+          value=""
+          onChange={() => {}}
+        />
+      );
+
+      expect(ref.current).toBeInstanceOf(HTMLInputElement);
+      expect(ref.current?.name).toBe('ref-test');
+    });
+
+    it('allows focus via ref', () => {
+      const ref = { current: null };
+
+      renderWithProviders(
+        <Input
+          ref={ref}
+          name="focus-test"
+          value=""
+          onChange={() => {}}
+        />
+      );
+
+      ref.current?.focus();
+      expect(ref.current).toHaveFocus();
+    });
+  });
+
+  describe('Custom Styling', () => {
+    it('applies custom className', () => {
+      const { container } = renderWithProviders(
+        <Input
+          name="test"
+          value=""
+          onChange={() => {}}
+          className="custom-wrapper-class"
+        />
+      );
+      const wrapper = container.firstChild;
+      expect(wrapper).toHaveClass('custom-wrapper-class');
+    });
+  });
+
+  describe('HTML Input Attributes', () => {
+    it('accepts and applies additional HTML input attributes', () => {
+      renderWithProviders(
+        <Input
+          name="test"
+          value=""
+          onChange={() => {}}
+          autoComplete="email"
+          data-testid="custom-input"
+        />
+      );
+      const input = screen.getByTestId('custom-input');
+      expect(input).toHaveAttribute('autocomplete', 'email');
+    });
+  });
+});

--- a/Frontend/EduLiteFrontend/src/pages/__tests__/NotFoundPage.integration.test.tsx
+++ b/Frontend/EduLiteFrontend/src/pages/__tests__/NotFoundPage.integration.test.tsx
@@ -1,0 +1,429 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { I18nextProvider } from 'react-i18next';
+import userEvent from '@testing-library/user-event';
+import NotFoundPage from '../NotFoundPage';
+import { AuthProvider } from '../../contexts/AuthContext';
+import i18n from '../../i18n';
+
+/**
+ * Integration tests for NotFoundPage with proper context mocking
+ * These tests verify behavior with different auth states and i18n
+ */
+
+// Mock the tokenService to control auth state
+vi.mock('../../services/tokenService', () => ({
+  initializeTokenService: vi.fn(),
+  setLogoutHandler: vi.fn(),
+  setStoredTokens: vi.fn(),
+  clearStoredTokens: vi.fn(),
+  shouldBeAuthenticated: vi.fn(() => false), // Default to not authenticated
+}));
+
+describe('NotFoundPage - Integration Tests', () => {
+  beforeEach(() => {
+    // Reset mocks before each test
+    vi.clearAllMocks();
+  });
+
+  describe('Authentication State Integration', () => {
+    it('shows Login and Sign Up links when not authenticated', async () => {
+      const { shouldBeAuthenticated } = await import('../../services/tokenService');
+      vi.mocked(shouldBeAuthenticated).mockReturnValue(false);
+
+      // Wait for auth check to complete
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      render(
+        <BrowserRouter>
+          <I18nextProvider i18n={i18n}>
+            <AuthProvider>
+              <NotFoundPage />
+            </AuthProvider>
+          </I18nextProvider>
+        </BrowserRouter>
+      );
+
+      // Should show login and signup links for unauthenticated users
+      const loginLink = screen.getByRole('link', { name: /login/i });
+      const signupLink = screen.getByRole('link', { name: /sign up/i });
+
+      expect(loginLink).toBeInTheDocument();
+      expect(signupLink).toBeInTheDocument();
+
+      // Should NOT show profile link
+      expect(screen.queryByRole('link', { name: /profile/i })).not.toBeInTheDocument();
+    });
+
+    it('shows Profile link when authenticated', async () => {
+      const { shouldBeAuthenticated } = await import('../../services/tokenService');
+      vi.mocked(shouldBeAuthenticated).mockReturnValue(true);
+
+      render(
+        <BrowserRouter>
+          <I18nextProvider i18n={i18n}>
+            <AuthProvider>
+              <NotFoundPage />
+            </AuthProvider>
+          </I18nextProvider>
+        </BrowserRouter>
+      );
+
+      // Wait for auth state to update
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      // Should show profile link for authenticated users
+      const profileLink = screen.getByRole('link', { name: /profile/i });
+      expect(profileLink).toBeInTheDocument();
+
+      // Should NOT show login/signup links
+      expect(screen.queryByRole('link', { name: /^login$/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: /sign up/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Navigation Integration', () => {
+    it('renders navigation links with correct hrefs', () => {
+      render(
+        <BrowserRouter>
+          <I18nextProvider i18n={i18n}>
+            <AuthProvider>
+              <NotFoundPage />
+            </AuthProvider>
+          </I18nextProvider>
+        </BrowserRouter>
+      );
+
+      const homeLink = screen.getByRole('link', { name: /go to home/i });
+      const aboutLink = screen.getByRole('link', { name: /about/i });
+
+      expect(homeLink).toHaveAttribute('href', '/');
+      expect(aboutLink).toHaveAttribute('href', '/about');
+    });
+
+    it('GitHub link opens in new tab with security attributes', () => {
+      render(
+        <BrowserRouter>
+          <I18nextProvider i18n={i18n}>
+            <AuthProvider>
+              <NotFoundPage />
+            </AuthProvider>
+          </I18nextProvider>
+        </BrowserRouter>
+      );
+
+      const githubLink = screen.getByRole('link', {
+        name: /github\.com\/ibrahim-sisar\/edulite\/issues/i
+      });
+
+      expect(githubLink).toHaveAttribute('href', 'https://github.com/ibrahim-sisar/EduLite/issues');
+      expect(githubLink).toHaveAttribute('target', '_blank');
+      expect(githubLink).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+  });
+
+  describe('window.history.back() Integration', () => {
+    it('calls window.history.back when Go Back button is clicked', async () => {
+      const mockHistoryBack = vi.fn();
+      const originalBack = window.history.back;
+      window.history.back = mockHistoryBack;
+
+      const user = userEvent.setup();
+
+      render(
+        <BrowserRouter>
+          <I18nextProvider i18n={i18n}>
+            <AuthProvider>
+              <NotFoundPage />
+            </AuthProvider>
+          </I18nextProvider>
+        </BrowserRouter>
+      );
+
+      const goBackButton = screen.getByRole('button', { name: /go back/i });
+      await user.click(goBackButton);
+
+      expect(mockHistoryBack).toHaveBeenCalledTimes(1);
+
+      // Restore original
+      window.history.back = originalBack;
+    });
+  });
+
+  describe('i18n Integration', () => {
+    it('renders with English language by default', () => {
+      render(
+        <BrowserRouter>
+          <I18nextProvider i18n={i18n}>
+            <AuthProvider>
+              <NotFoundPage />
+            </AuthProvider>
+          </I18nextProvider>
+        </BrowserRouter>
+      );
+
+      // Check for English text
+      expect(screen.getByText('404')).toBeInTheDocument();
+      expect(screen.getByText(/page not found/i)).toBeInTheDocument();
+      expect(screen.getByText(/go to home/i)).toBeInTheDocument();
+    });
+
+    // Note: Testing language switching would require more complex i18n setup
+    // and is typically covered by i18n-specific tests
+  });
+
+  describe('Component Structure Integration', () => {
+    it('renders all major sections', () => {
+      const { container } = render(
+        <BrowserRouter>
+          <I18nextProvider i18n={i18n}>
+            <AuthProvider>
+              <NotFoundPage />
+            </AuthProvider>
+          </I18nextProvider>
+        </BrowserRouter>
+      );
+
+      // Check for main sections
+      const mainHeading = screen.getByRole('heading', { level: 1, name: '404' });
+      const subHeading = screen.getByRole('heading', { level: 2, name: /page not found/i });
+
+      expect(mainHeading).toBeInTheDocument();
+      expect(subHeading).toBeInTheDocument();
+
+      // Check for action buttons section
+      const homeLink = screen.getByRole('link', { name: /go to home/i });
+      const goBackButton = screen.getByRole('button', { name: /go back/i });
+
+      expect(homeLink).toBeInTheDocument();
+      expect(goBackButton).toBeInTheDocument();
+
+      // Check for helpful links section
+      expect(screen.getByText(/here are some helpful links/i)).toBeInTheDocument();
+
+      // Check for contribute section
+      expect(screen.getByText(/do you think this page should exist/i)).toBeInTheDocument();
+    });
+
+    it('has proper semantic HTML structure', () => {
+      render(
+        <BrowserRouter>
+          <I18nextProvider i18n={i18n}>
+            <AuthProvider>
+              <NotFoundPage />
+            </AuthProvider>
+          </I18nextProvider>
+        </BrowserRouter>
+      );
+
+      // Check heading hierarchy
+      const h1 = screen.getByRole('heading', { level: 1 });
+      const h2 = screen.getByRole('heading', { level: 2 });
+
+      expect(h1).toBeInTheDocument();
+      expect(h2).toBeInTheDocument();
+
+      // Check for proper link structure
+      const links = screen.getAllByRole('link');
+      expect(links.length).toBeGreaterThan(0);
+
+      links.forEach(link => {
+        expect(link).toHaveAttribute('href');
+      });
+    });
+  });
+
+  describe('Icons Integration', () => {
+    it('renders all icon components', () => {
+      const { container } = render(
+        <BrowserRouter>
+          <I18nextProvider i18n={i18n}>
+            <AuthProvider>
+              <NotFoundPage />
+            </AuthProvider>
+          </I18nextProvider>
+        </BrowserRouter>
+      );
+
+      // React Icons render as SVG elements
+      const svgElements = container.querySelectorAll('svg');
+
+      // Should have icons for:
+      // 1. Exclamation triangle (error icon)
+      // 2. Home icon
+      // 3. Arrow left (go back)
+      // 4. GitHub icon
+      expect(svgElements.length).toBeGreaterThanOrEqual(4);
+    });
+
+    it('icons have proper aria-hidden or accessible labels', () => {
+      render(
+        <BrowserRouter>
+          <I18nextProvider i18n={i18n}>
+            <AuthProvider>
+              <NotFoundPage />
+            </AuthProvider>
+          </I18nextProvider>
+        </BrowserRouter>
+      );
+
+      // Icons should either be decorative (aria-hidden) or have accessible text
+      const homeLink = screen.getByRole('link', { name: /go to home/i });
+      const goBackButton = screen.getByRole('button', { name: /go back/i });
+
+      // These should have accessible names from their text content
+      expect(homeLink).toHaveAccessibleName();
+      expect(goBackButton).toHaveAccessibleName();
+    });
+  });
+
+  describe('Responsive Design Integration', () => {
+    it('uses responsive Tailwind classes', () => {
+      const { container } = render(
+        <BrowserRouter>
+          <I18nextProvider i18n={i18n}>
+            <AuthProvider>
+              <NotFoundPage />
+            </AuthProvider>
+          </I18nextProvider>
+        </BrowserRouter>
+      );
+
+      // Check for responsive flex classes
+      const flexContainer = container.querySelector('.flex.flex-col.sm\\:flex-row');
+      expect(flexContainer).toBeInTheDocument();
+    });
+  });
+
+  describe('Dark Mode Integration', () => {
+    it('includes dark mode classes for all elements', () => {
+      const { container } = render(
+        <BrowserRouter>
+          <I18nextProvider i18n={i18n}>
+            <AuthProvider>
+              <NotFoundPage />
+            </AuthProvider>
+          </I18nextProvider>
+        </BrowserRouter>
+      );
+
+      // Check for dark mode classes in main container
+      const mainContainer = container.querySelector('.dark\\:from-gray-900');
+      expect(mainContainer).toBeInTheDocument();
+
+      // Check text elements have dark mode variants
+      const pageTitle = screen.getByText(/page not found/i);
+      expect(pageTitle).toHaveClass('dark:text-white');
+    });
+  });
+
+  describe('Full User Journey Integration', () => {
+    it('simulates complete user interaction flow', async () => {
+      const user = userEvent.setup();
+      const mockHistoryBack = vi.fn();
+      window.history.back = mockHistoryBack;
+
+      render(
+        <BrowserRouter>
+          <I18nextProvider i18n={i18n}>
+            <AuthProvider>
+              <NotFoundPage />
+            </AuthProvider>
+          </I18nextProvider>
+        </BrowserRouter>
+      );
+
+      // 1. User sees the 404 error
+      expect(screen.getByText('404')).toBeInTheDocument();
+
+      // 2. User reads the error message
+      expect(screen.getByText(/page not found/i)).toBeInTheDocument();
+
+      // 3. User considers their options
+      const homeLink = screen.getByRole('link', { name: /go to home/i });
+      const goBackButton = screen.getByRole('button', { name: /go back/i });
+      const aboutLink = screen.getByRole('link', { name: /about/i });
+
+      expect(homeLink).toBeInTheDocument();
+      expect(goBackButton).toBeInTheDocument();
+      expect(aboutLink).toBeInTheDocument();
+
+      // 4. User clicks "Go Back"
+      await user.click(goBackButton);
+      expect(mockHistoryBack).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Error Boundaries and Edge Cases', () => {
+    it('renders even if AuthContext has errors', () => {
+      // This tests resilience to context errors
+      render(
+        <BrowserRouter>
+          <I18nextProvider i18n={i18n}>
+            <AuthProvider>
+              <NotFoundPage />
+            </AuthProvider>
+          </I18nextProvider>
+        </BrowserRouter>
+      );
+
+      // Page should still render
+      expect(screen.getByText('404')).toBeInTheDocument();
+    });
+
+    it('renders even if i18n is not fully initialized', () => {
+      // Test with minimal i18n setup
+      render(
+        <BrowserRouter>
+          <I18nextProvider i18n={i18n}>
+            <AuthProvider>
+              <NotFoundPage />
+            </AuthProvider>
+          </I18nextProvider>
+        </BrowserRouter>
+      );
+
+      expect(screen.getByText('404')).toBeInTheDocument();
+    });
+  });
+
+  describe('Link Navigation Edge Cases', () => {
+    it('all internal links use relative paths', () => {
+      render(
+        <BrowserRouter>
+          <I18nextProvider i18n={i18n}>
+            <AuthProvider>
+              <NotFoundPage />
+            </AuthProvider>
+          </I18nextProvider>
+        </BrowserRouter>
+      );
+
+      const homeLink = screen.getByRole('link', { name: /go to home/i });
+      const aboutLink = screen.getByRole('link', { name: /about/i });
+
+      expect(homeLink.getAttribute('href')).toMatch(/^\//);
+      expect(aboutLink.getAttribute('href')).toMatch(/^\//);
+    });
+
+    it('external links open in new tab', () => {
+      render(
+        <BrowserRouter>
+          <I18nextProvider i18n={i18n}>
+            <AuthProvider>
+              <NotFoundPage />
+            </AuthProvider>
+          </I18nextProvider>
+        </BrowserRouter>
+      );
+
+      const githubLink = screen.getByRole('link', {
+        name: /github\.com\/ibrahim-sisar\/edulite\/issues/i
+      });
+
+      expect(githubLink).toHaveAttribute('target', '_blank');
+    });
+  });
+});

--- a/Frontend/EduLiteFrontend/src/pages/__tests__/NotFoundPage.integration.test.tsx
+++ b/Frontend/EduLiteFrontend/src/pages/__tests__/NotFoundPage.integration.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import React from 'react';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { I18nextProvider } from 'react-i18next';
 import userEvent from '@testing-library/user-event';
@@ -176,7 +175,7 @@ describe('NotFoundPage - Integration Tests', () => {
 
   describe('Component Structure Integration', () => {
     it('renders all major sections', () => {
-      const { container } = render(
+      render(
         <BrowserRouter>
           <I18nextProvider i18n={i18n}>
             <AuthProvider>

--- a/Frontend/EduLiteFrontend/src/pages/__tests__/NotFoundPage.test.tsx
+++ b/Frontend/EduLiteFrontend/src/pages/__tests__/NotFoundPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { renderWithProviders, screen, within } from '@/test/utils';
+import { renderWithProviders, screen } from '@/test/utils';
 import NotFoundPage from '../NotFoundPage';
 
 describe('NotFoundPage', () => {
@@ -104,7 +104,7 @@ describe('NotFoundPage', () => {
     it('renders home icon in Go to Home link', () => {
       renderWithProviders(<NotFoundPage />);
       const homeLink = screen.getByRole('link', { name: /go to home/i });
-      const icon = within(homeLink).getByTestId = homeLink.querySelector('svg');
+      const icon = homeLink.querySelector('svg');
       expect(icon).toBeInTheDocument();
     });
 

--- a/Frontend/EduLiteFrontend/src/pages/__tests__/NotFoundPage.test.tsx
+++ b/Frontend/EduLiteFrontend/src/pages/__tests__/NotFoundPage.test.tsx
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders, screen, within } from '@/test/utils';
+import NotFoundPage from '../NotFoundPage';
+
+describe('NotFoundPage', () => {
+  describe('Rendering', () => {
+    it('renders the 404 error code', () => {
+      renderWithProviders(<NotFoundPage />);
+      expect(screen.getByText('404')).toBeInTheDocument();
+    });
+
+    it('renders the page title', () => {
+      renderWithProviders(<NotFoundPage />);
+      expect(screen.getByText(/page not found/i)).toBeInTheDocument();
+    });
+
+    it('renders the error description', () => {
+      renderWithProviders(<NotFoundPage />);
+      expect(
+        screen.getByText(/the page you're looking for doesn't exist/i)
+      ).toBeInTheDocument();
+    });
+
+    it('renders the exclamation triangle icon', () => {
+      renderWithProviders(<NotFoundPage />);
+      // The icon is rendered as an SVG element
+      const iconContainer = document.querySelector('.text-5xl.text-blue-500');
+      expect(iconContainer).toBeInTheDocument();
+    });
+  });
+
+  describe('Navigation Links', () => {
+    it('renders "Go to Home" link', () => {
+      renderWithProviders(<NotFoundPage />);
+      const homeLink = screen.getByRole('link', { name: /go to home/i });
+      expect(homeLink).toBeInTheDocument();
+      expect(homeLink).toHaveAttribute('href', '/');
+    });
+
+    it('renders "Go Back" button', () => {
+      renderWithProviders(<NotFoundPage />);
+      const backButton = screen.getByRole('button', { name: /go back/i });
+      expect(backButton).toBeInTheDocument();
+    });
+
+    it('renders "About" link', () => {
+      renderWithProviders(<NotFoundPage />);
+      const aboutLink = screen.getByRole('link', { name: /about/i });
+      expect(aboutLink).toBeInTheDocument();
+      expect(aboutLink).toHaveAttribute('href', '/about');
+    });
+  });
+
+  describe('Authenticated vs Unauthenticated States', () => {
+    // Note: The default renderWithProviders provides a mocked AuthContext
+    // In a real scenario, you would create separate test utilities or
+    // modify renderWithProviders to accept custom context values
+
+    it('renders auth-dependent links based on login state', () => {
+      renderWithProviders(<NotFoundPage />);
+
+      // The component should render either login/signup OR profile links
+      // depending on the auth state from the provider
+      const links = screen.getAllByRole('link');
+      expect(links.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('GitHub Link', () => {
+    it('renders GitHub issues link', () => {
+      renderWithProviders(<NotFoundPage />);
+      const githubLink = screen.getByRole('link', {
+        name: /github\.com\/ibrahim-sisar\/edulite\/issues/i
+      });
+      expect(githubLink).toBeInTheDocument();
+      expect(githubLink).toHaveAttribute('href', 'https://github.com/ibrahim-sisar/EduLite/issues');
+      expect(githubLink).toHaveAttribute('target', '_blank');
+      expect(githubLink).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+
+    it('renders the contribute section', () => {
+      renderWithProviders(<NotFoundPage />);
+      expect(
+        screen.getByText(/do you think this page should exist\?/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Styling and Layout', () => {
+    it('has proper gradient background', () => {
+      const { container } = renderWithProviders(<NotFoundPage />);
+      const mainDiv = container.querySelector('.min-h-\\[60vh\\]');
+      expect(mainDiv).toHaveClass('bg-gradient-to-br');
+    });
+
+    it('renders with proper spacing (pt-24)', () => {
+      const { container } = renderWithProviders(<NotFoundPage />);
+      const mainDiv = container.querySelector('.pt-24');
+      expect(mainDiv).toBeInTheDocument();
+    });
+  });
+
+  describe('Icons', () => {
+    it('renders home icon in Go to Home link', () => {
+      renderWithProviders(<NotFoundPage />);
+      const homeLink = screen.getByRole('link', { name: /go to home/i });
+      const icon = within(homeLink).getByTestId = homeLink.querySelector('svg');
+      expect(icon).toBeInTheDocument();
+    });
+
+    it('renders back arrow icon in Go Back button', () => {
+      renderWithProviders(<NotFoundPage />);
+      const backButton = screen.getByRole('button', { name: /go back/i });
+      const icon = backButton.querySelector('svg');
+      expect(icon).toBeInTheDocument();
+    });
+
+    it('renders GitHub icon', () => {
+      renderWithProviders(<NotFoundPage />);
+      // GitHub icon is rendered near the contribute section
+      const githubIcon = document.querySelector('.text-xl.text-gray-600');
+      expect(githubIcon).toBeInTheDocument();
+    });
+  });
+
+  describe('User Interactions', () => {
+    it('calls window.history.back() when Go Back button is clicked', () => {
+      const mockBack = vi.fn();
+      window.history.back = mockBack;
+
+      renderWithProviders(<NotFoundPage />);
+      const backButton = screen.getByRole('button', { name: /go back/i });
+
+      backButton.click();
+      expect(mockBack).toHaveBeenCalled();
+    });
+  });
+
+  describe('Responsive Design', () => {
+    it('uses responsive flex classes for action buttons', () => {
+      const { container } = renderWithProviders(<NotFoundPage />);
+      const buttonContainer = container.querySelector('.flex.flex-col.sm\\:flex-row');
+      expect(buttonContainer).toBeInTheDocument();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('has proper semantic structure with headings', () => {
+      renderWithProviders(<NotFoundPage />);
+
+      // Main heading (404)
+      const mainHeading = screen.getByRole('heading', { level: 1 });
+      expect(mainHeading).toHaveTextContent('404');
+
+      // Subheading (Page Not Found)
+      const subHeading = screen.getByRole('heading', { level: 2 });
+      expect(subHeading).toHaveTextContent(/page not found/i);
+    });
+
+    it('has properly styled and accessible links', () => {
+      renderWithProviders(<NotFoundPage />);
+      const homeLink = screen.getByRole('link', { name: /go to home/i });
+
+      expect(homeLink).toHaveClass('rounded-2xl', 'transition-all');
+    });
+
+    it('external links have proper security attributes', () => {
+      renderWithProviders(<NotFoundPage />);
+      const githubLink = screen.getByRole('link', {
+        name: /github\.com\/ibrahim-sisar\/edulite\/issues/i
+      });
+
+      // Check for security best practices
+      expect(githubLink).toHaveAttribute('rel', 'noopener noreferrer');
+      expect(githubLink).toHaveAttribute('target', '_blank');
+    });
+  });
+
+  describe('Dark Mode Support', () => {
+    it('has dark mode classes on main container', () => {
+      const { container } = renderWithProviders(<NotFoundPage />);
+      const mainDiv = container.querySelector('.dark\\:from-gray-900');
+      expect(mainDiv).toBeInTheDocument();
+    });
+
+    it('has dark mode classes on text elements', () => {
+      renderWithProviders(<NotFoundPage />);
+      const pageTitle = screen.getByText(/page not found/i);
+      expect(pageTitle).toHaveClass('dark:text-white');
+    });
+  });
+});

--- a/Frontend/EduLiteFrontend/src/services/__tests__/choicesService.test.ts
+++ b/Frontend/EduLiteFrontend/src/services/__tests__/choicesService.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { choicesService, Choice, ChoiceType } from '../choicesService';
+import { choicesService, Choice } from '../choicesService';
 
 // Mock data
 const mockOccupations: Choice[] = [
@@ -42,7 +42,7 @@ describe('choicesService - Caching Strategy', () => {
         ok: true,
         headers: { get: () => 'application/json' },
         text: async () => JSON.stringify(mockOccupations),
-      } as Response);
+      } as unknown as Response);
 
       // First call - fetches from network
       const result1 = await choicesService.getChoices('occupations');
@@ -61,12 +61,12 @@ describe('choicesService - Caching Strategy', () => {
           ok: true,
           headers: { get: () => 'application/json' },
           text: async () => JSON.stringify(mockOccupations),
-        } as Response)
+        } as unknown as Response)
         .mockResolvedValueOnce({
           ok: true,
           headers: { get: () => 'application/json' },
           text: async () => JSON.stringify(mockCountries),
-        } as Response);
+        } as unknown as Response);
 
       await choicesService.getChoices('occupations');
       await choicesService.getChoices('countries');
@@ -100,7 +100,7 @@ describe('choicesService - Caching Strategy', () => {
         ok: true,
         headers: { get: () => 'application/json' },
         text: async () => JSON.stringify(mockCountries),
-      } as Response);
+      } as unknown as Response);
 
       await choicesService.getChoices('countries');
 
@@ -117,7 +117,7 @@ describe('choicesService - Caching Strategy', () => {
         ok: true,
         headers: { get: () => 'application/json' },
         text: async () => JSON.stringify(mockLanguages),
-      } as Response);
+      } as unknown as Response);
 
       // Should remove corrupted cache and fetch fresh
       const result = await choicesService.getChoices('languages');
@@ -138,7 +138,7 @@ describe('choicesService - Caching Strategy', () => {
         ok: true,
         headers: { get: () => 'application/json' },
         text: async () => JSON.stringify(mockOccupations),
-      } as Response);
+      } as unknown as Response);
 
       const result = await choicesService.getChoices('occupations');
 
@@ -154,7 +154,7 @@ describe('choicesService - Caching Strategy', () => {
         ok: true,
         headers: { get: () => 'application/json' },
         text: async () => JSON.stringify(mockCountries),
-      } as Response);
+      } as unknown as Response);
 
       await choicesService.getChoices('countries');
 
@@ -184,7 +184,7 @@ describe('choicesService - Fetch & Retry Logic', () => {
       ok: true,
       headers: { get: () => 'application/json' },
       text: async () => JSON.stringify(mockOccupations),
-    } as Response);
+    } as unknown as Response);
 
     const result = await choicesService.getChoices('occupations');
 
@@ -199,13 +199,13 @@ describe('choicesService - Fetch & Retry Logic', () => {
         ok: true,
         headers: { get: () => 'text/html' },
         text: async () => '<html>404 page</html>',
-      } as Response)
+      } as unknown as Response)
       // Second attempt: JSON response
       .mockResolvedValueOnce({
         ok: true,
         headers: { get: () => 'application/json' },
         text: async () => JSON.stringify(mockCountries),
-      } as Response);
+      } as unknown as Response);
 
     const result = await choicesService.getChoices('countries');
 
@@ -221,7 +221,7 @@ describe('choicesService - Fetch & Retry Logic', () => {
       ok: true,
       headers: { get: () => 'text/html' },
       text: async () => '<html>404</html>',
-    } as Response);
+    } as unknown as Response);
 
     const result = await choicesService.getChoices('languages');
 
@@ -240,7 +240,7 @@ describe('choicesService - Fetch & Retry Logic', () => {
       statusText: 'Not Found',
       headers: { get: () => 'application/json' },
       text: async () => 'Not found',
-    } as Response);
+    } as unknown as Response);
 
     const result = await choicesService.getChoices('occupations');
 
@@ -271,12 +271,12 @@ describe('choicesService - Fetch & Retry Logic', () => {
         ok: true,
         headers: { get: () => 'text/html' },
         text: async () => '<html>404</html>',
-      } as Response)
+      } as unknown as Response)
       .mockResolvedValueOnce({
         ok: true,
         headers: { get: () => 'application/json' },
         text: async () => JSON.stringify(mockLanguages),
-      } as Response);
+      } as unknown as Response);
 
     const promise = choicesService.getChoices('languages');
 
@@ -313,7 +313,7 @@ describe('choicesService - Data Validation', () => {
         { value: 'test1', label: 'Test 1' },
         { value: 'test2', label: 'Test 2' },
       ]),
-    } as Response);
+    } as unknown as Response);
 
     const result = await choicesService.getChoices('occupations');
 
@@ -330,7 +330,7 @@ describe('choicesService - Data Validation', () => {
         { label: 'Test 1' }, // Missing value
         { value: 'test2', label: 'Test 2' },
       ]),
-    } as Response);
+    } as unknown as Response);
 
     const result = await choicesService.getChoices('countries');
 
@@ -349,7 +349,7 @@ describe('choicesService - Data Validation', () => {
         { value: 'test1' }, // Missing label
         { value: 'test2', label: 'Test 2' },
       ]),
-    } as Response);
+    } as unknown as Response);
 
     const result = await choicesService.getChoices('languages');
 
@@ -361,7 +361,7 @@ describe('choicesService - Data Validation', () => {
       ok: true,
       headers: { get: () => 'application/json' },
       text: async () => JSON.stringify({ error: 'Not an array' }),
-    } as Response);
+    } as unknown as Response);
 
     const result = await choicesService.getChoices('occupations');
 
@@ -373,7 +373,7 @@ describe('choicesService - Data Validation', () => {
       ok: true,
       headers: { get: () => 'application/json' },
       text: async () => '{invalid json{{',
-    } as Response);
+    } as unknown as Response);
 
     const result = await choicesService.getChoices('countries');
 
@@ -389,7 +389,7 @@ describe('choicesService - Data Validation', () => {
       ok: true,
       headers: { get: () => 'application/json' },
       text: async () => '[]',
-    } as Response);
+    } as unknown as Response);
 
     const result = await choicesService.getChoices('languages');
 
@@ -419,7 +419,7 @@ describe('choicesService - Convenience Methods', () => {
       ok: true,
       headers: { get: () => 'application/json' },
       text: async () => JSON.stringify(mockOccupations),
-    } as Response);
+    } as unknown as Response);
 
     const result = await choicesService.getOccupationChoices();
 
@@ -435,7 +435,7 @@ describe('choicesService - Convenience Methods', () => {
       ok: true,
       headers: { get: () => 'application/json' },
       text: async () => JSON.stringify(mockCountries),
-    } as Response);
+    } as unknown as Response);
 
     const result = await choicesService.getCountryChoices();
 
@@ -451,7 +451,7 @@ describe('choicesService - Convenience Methods', () => {
       ok: true,
       headers: { get: () => 'application/json' },
       text: async () => JSON.stringify(mockLanguages),
-    } as Response);
+    } as unknown as Response);
 
     const result = await choicesService.getLanguageChoices();
 
@@ -483,12 +483,12 @@ describe('choicesService - Cache Management', () => {
         ok: true,
         headers: { get: () => 'application/json' },
         text: async () => JSON.stringify(mockOccupations),
-      } as Response)
+      } as unknown as Response)
       .mockResolvedValueOnce({
         ok: true,
         headers: { get: () => 'application/json' },
         text: async () => JSON.stringify(mockCountries),
-      } as Response);
+      } as unknown as Response);
 
     await choicesService.getChoices('occupations');
     await choicesService.getChoices('countries');
@@ -503,7 +503,7 @@ describe('choicesService - Cache Management', () => {
       ok: true,
       headers: { get: () => 'application/json' },
       text: async () => JSON.stringify(mockOccupations),
-    } as Response);
+    } as unknown as Response);
 
     // Occupations should fetch again, countries should use cache
     await choicesService.getChoices('occupations');
@@ -519,17 +519,17 @@ describe('choicesService - Cache Management', () => {
         ok: true,
         headers: { get: () => 'application/json' },
         text: async () => JSON.stringify(mockOccupations),
-      } as Response)
+      } as unknown as Response)
       .mockResolvedValueOnce({
         ok: true,
         headers: { get: () => 'application/json' },
         text: async () => JSON.stringify(mockCountries),
-      } as Response)
+      } as unknown as Response)
       .mockResolvedValueOnce({
         ok: true,
         headers: { get: () => 'application/json' },
         text: async () => JSON.stringify(mockLanguages),
-      } as Response);
+      } as unknown as Response);
 
     await choicesService.getChoices('occupations');
     await choicesService.getChoices('countries');
@@ -546,12 +546,12 @@ describe('choicesService - Cache Management', () => {
         ok: true,
         headers: { get: () => 'application/json' },
         text: async () => JSON.stringify(mockOccupations),
-      } as Response)
+      } as unknown as Response)
       .mockResolvedValueOnce({
         ok: true,
         headers: { get: () => 'application/json' },
         text: async () => JSON.stringify(mockCountries),
-      } as Response);
+      } as unknown as Response);
 
     // All should fetch again
     await choicesService.getChoices('occupations');
@@ -565,7 +565,7 @@ describe('choicesService - Cache Management', () => {
       ok: true,
       headers: { get: () => 'application/json' },
       text: async () => JSON.stringify(mockOccupations),
-    } as Response);
+    } as unknown as Response);
 
     await choicesService.getChoices('occupations');
 
@@ -597,7 +597,7 @@ describe('choicesService - Offline Support', () => {
       ok: true,
       headers: { get: () => 'application/json' },
       text: async () => JSON.stringify(mockOccupations),
-    } as Response);
+    } as unknown as Response);
 
     await choicesService.getChoices('occupations');
 
@@ -625,17 +625,17 @@ describe('choicesService - Offline Support', () => {
         ok: true,
         headers: { get: () => 'application/json' },
         text: async () => JSON.stringify(mockOccupations),
-      } as Response)
+      } as unknown as Response)
       .mockResolvedValueOnce({
         ok: true,
         headers: { get: () => 'application/json' },
         text: async () => JSON.stringify(mockCountries),
-      } as Response)
+      } as unknown as Response)
       .mockResolvedValueOnce({
         ok: true,
         headers: { get: () => 'application/json' },
         text: async () => JSON.stringify(mockLanguages),
-      } as Response);
+      } as unknown as Response);
 
     await choicesService.preloadAllChoices();
 
@@ -651,13 +651,13 @@ describe('choicesService - Offline Support', () => {
         ok: true,
         headers: { get: () => 'application/json' },
         text: async () => JSON.stringify(mockOccupations),
-      } as Response)
+      } as unknown as Response)
       .mockRejectedValueOnce(new Error('Network error')) // Countries fail
       .mockResolvedValueOnce({
         ok: true,
         headers: { get: () => 'application/json' },
         text: async () => JSON.stringify(mockLanguages),
-      } as Response);
+      } as unknown as Response);
 
     await choicesService.preloadAllChoices();
 
@@ -702,7 +702,7 @@ describe('choicesService - Edge Cases', () => {
       ok: true,
       headers: { get: () => 'application/json' },
       text: async () => JSON.stringify(mockOccupations),
-    } as Response);
+    } as unknown as Response);
 
     // Make 3 concurrent requests
     const promises = [
@@ -727,7 +727,7 @@ describe('choicesService - Edge Cases', () => {
       ok: true,
       headers: { get: () => 'application/json' },
       text: async () => JSON.stringify([]),
-    } as Response);
+    } as unknown as Response);
 
     const result = await choicesService.getChoices('countries');
 

--- a/Frontend/EduLiteFrontend/src/services/__tests__/choicesService.test.ts
+++ b/Frontend/EduLiteFrontend/src/services/__tests__/choicesService.test.ts
@@ -1,0 +1,752 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { choicesService, Choice, ChoiceType } from '../choicesService';
+
+// Mock data
+const mockOccupations: Choice[] = [
+  { value: 'engineer', label: 'Engineer' },
+  { value: 'teacher', label: 'Teacher' },
+  { value: 'doctor', label: 'Doctor' },
+];
+
+const mockCountries: Choice[] = [
+  { value: 'us', label: 'United States' },
+  { value: 'uk', label: 'United Kingdom' },
+  { value: 'ca', label: 'Canada' },
+];
+
+const mockLanguages: Choice[] = [
+  { value: 'en', label: 'English' },
+  { value: 'ar', label: 'Arabic' },
+  { value: 'es', label: 'Spanish' },
+];
+
+// Mock fetch globally
+global.fetch = vi.fn();
+
+describe('choicesService - Caching Strategy', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    choicesService.clearCache();
+    vi.clearAllMocks();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('Memory Cache', () => {
+    it('returns data from memory cache on subsequent calls', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => 'application/json' },
+        text: async () => JSON.stringify(mockOccupations),
+      } as Response);
+
+      // First call - fetches from network
+      const result1 = await choicesService.getChoices('occupations');
+      expect(result1).toEqual(mockOccupations);
+      expect(fetch).toHaveBeenCalledTimes(1);
+
+      // Second call - should use memory cache (no additional fetch)
+      const result2 = await choicesService.getChoices('occupations');
+      expect(result2).toEqual(mockOccupations);
+      expect(fetch).toHaveBeenCalledTimes(1); // Still just 1 call
+    });
+
+    it('memory cache persists across different choice types', async () => {
+      vi.mocked(fetch)
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: { get: () => 'application/json' },
+          text: async () => JSON.stringify(mockOccupations),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: { get: () => 'application/json' },
+          text: async () => JSON.stringify(mockCountries),
+        } as Response);
+
+      await choicesService.getChoices('occupations');
+      await choicesService.getChoices('countries');
+
+      // Both should be cached in memory
+      expect(fetch).toHaveBeenCalledTimes(2);
+
+      // Retrieve again - should use memory cache
+      await choicesService.getChoices('occupations');
+      await choicesService.getChoices('countries');
+      expect(fetch).toHaveBeenCalledTimes(2); // No additional fetches
+    });
+  });
+
+  describe('localStorage Cache', () => {
+    it('returns data from localStorage when memory cache is cold', async () => {
+      // Pre-populate localStorage
+      localStorage.setItem(
+        'edulite_choices_occupations_v1.0',
+        JSON.stringify(mockOccupations)
+      );
+
+      // Should load from localStorage without fetching
+      const result = await choicesService.getChoices('occupations');
+      expect(result).toEqual(mockOccupations);
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('stores fetched data in localStorage for future use', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => 'application/json' },
+        text: async () => JSON.stringify(mockCountries),
+      } as Response);
+
+      await choicesService.getChoices('countries');
+
+      // Check localStorage was updated
+      const cached = localStorage.getItem('edulite_choices_countries_v1.0');
+      expect(cached).toBe(JSON.stringify(mockCountries));
+    });
+
+    it('handles corrupted localStorage data gracefully', async () => {
+      // Store invalid JSON
+      localStorage.setItem('edulite_choices_languages_v1.0', 'invalid-json{{{');
+
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => 'application/json' },
+        text: async () => JSON.stringify(mockLanguages),
+      } as Response);
+
+      // Should remove corrupted cache and fetch fresh
+      const result = await choicesService.getChoices('languages');
+      expect(result).toEqual(mockLanguages);
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to parse cached'),
+        expect.anything()
+      );
+      expect(localStorage.getItem('edulite_choices_languages_v1.0')).toBe(
+        JSON.stringify(mockLanguages)
+      );
+    });
+  });
+
+  describe('Network Fetch', () => {
+    it('fetches from network when no cache exists', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => 'application/json' },
+        text: async () => JSON.stringify(mockOccupations),
+      } as Response);
+
+      const result = await choicesService.getChoices('occupations');
+
+      expect(fetch).toHaveBeenCalledWith(
+        '/project_choices_data/occupations.json',
+        { cache: 'force-cache' }
+      );
+      expect(result).toEqual(mockOccupations);
+    });
+
+    it('uses force-cache for browser caching', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => 'application/json' },
+        text: async () => JSON.stringify(mockCountries),
+      } as Response);
+
+      await choicesService.getChoices('countries');
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining('countries.json'),
+        expect.objectContaining({ cache: 'force-cache' })
+      );
+    });
+  });
+});
+
+describe('choicesService - Fetch & Retry Logic', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    choicesService.clearCache();
+    vi.clearAllMocks();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('successfully fetches JSON on first attempt', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => 'application/json' },
+      text: async () => JSON.stringify(mockOccupations),
+    } as Response);
+
+    const result = await choicesService.getChoices('occupations');
+
+    expect(result).toEqual(mockOccupations);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries when receiving HTML instead of JSON', async () => {
+    // First attempt: HTML response
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => 'text/html' },
+        text: async () => '<html>404 page</html>',
+      } as Response)
+      // Second attempt: JSON response
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => 'application/json' },
+        text: async () => JSON.stringify(mockCountries),
+      } as Response);
+
+    const result = await choicesService.getChoices('countries');
+
+    expect(result).toEqual(mockCountries);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('[Attempt 1/3] Got HTML instead of JSON')
+    );
+  });
+
+  it('exhausts retries and returns empty array after 3 HTML responses', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      headers: { get: () => 'text/html' },
+      text: async () => '<html>404</html>',
+    } as Response);
+
+    const result = await choicesService.getChoices('languages');
+
+    expect(result).toEqual([]);
+    expect(fetch).toHaveBeenCalledTimes(3); // Max retries
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Final attempt'),
+      expect.anything()
+    );
+  });
+
+  it('handles non-OK HTTP status', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      headers: { get: () => 'application/json' },
+      text: async () => 'Not found',
+    } as Response);
+
+    const result = await choicesService.getChoices('occupations');
+
+    expect(result).toEqual([]);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to fetch'),
+      expect.anything()
+    );
+  });
+
+  it('handles network errors gracefully', async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'));
+
+    const result = await choicesService.getChoices('countries');
+
+    expect(result).toEqual([]);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Error loading'),
+      expect.any(Error)
+    );
+  });
+
+  it('waits 150ms between retries', async () => {
+    vi.useFakeTimers();
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => 'text/html' },
+        text: async () => '<html>404</html>',
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => 'application/json' },
+        text: async () => JSON.stringify(mockLanguages),
+      } as Response);
+
+    const promise = choicesService.getChoices('languages');
+
+    // Fast-forward time
+    await vi.advanceTimersByTimeAsync(150);
+
+    const result = await promise;
+
+    expect(result).toEqual(mockLanguages);
+    expect(fetch).toHaveBeenCalledTimes(2);
+
+    vi.useRealTimers();
+  });
+});
+
+describe('choicesService - Data Validation', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    choicesService.clearCache();
+    vi.clearAllMocks();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('validates data structure has value and label fields', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => 'application/json' },
+      text: async () => JSON.stringify([
+        { value: 'test1', label: 'Test 1' },
+        { value: 'test2', label: 'Test 2' },
+      ]),
+    } as Response);
+
+    const result = await choicesService.getChoices('occupations');
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toHaveProperty('value');
+    expect(result[0]).toHaveProperty('label');
+  });
+
+  it('rejects invalid data structure (missing value)', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => 'application/json' },
+      text: async () => JSON.stringify([
+        { label: 'Test 1' }, // Missing value
+        { value: 'test2', label: 'Test 2' },
+      ]),
+    } as Response);
+
+    const result = await choicesService.getChoices('countries');
+
+    expect(result).toEqual([]);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Error loading'),
+      expect.anything()
+    );
+  });
+
+  it('rejects invalid data structure (missing label)', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => 'application/json' },
+      text: async () => JSON.stringify([
+        { value: 'test1' }, // Missing label
+        { value: 'test2', label: 'Test 2' },
+      ]),
+    } as Response);
+
+    const result = await choicesService.getChoices('languages');
+
+    expect(result).toEqual([]);
+  });
+
+  it('rejects non-array data', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => 'application/json' },
+      text: async () => JSON.stringify({ error: 'Not an array' }),
+    } as Response);
+
+    const result = await choicesService.getChoices('occupations');
+
+    expect(result).toEqual([]);
+  });
+
+  it('handles malformed JSON', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => 'application/json' },
+      text: async () => '{invalid json{{',
+    } as Response);
+
+    const result = await choicesService.getChoices('countries');
+
+    expect(result).toEqual([]);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('JSON parsing failed'),
+      expect.anything()
+    );
+  });
+
+  it('warns about suspiciously short responses', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => 'application/json' },
+      text: async () => '[]',
+    } as Response);
+
+    const result = await choicesService.getChoices('languages');
+
+    expect(result).toEqual([]);
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Suspiciously short response'),
+      '[]'
+    );
+  });
+});
+
+describe('choicesService - Convenience Methods', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    choicesService.clearCache();
+    vi.clearAllMocks();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('getOccupationChoices() fetches occupations', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => 'application/json' },
+      text: async () => JSON.stringify(mockOccupations),
+    } as Response);
+
+    const result = await choicesService.getOccupationChoices();
+
+    expect(result).toEqual(mockOccupations);
+    expect(fetch).toHaveBeenCalledWith(
+      '/project_choices_data/occupations.json',
+      expect.anything()
+    );
+  });
+
+  it('getCountryChoices() fetches countries', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => 'application/json' },
+      text: async () => JSON.stringify(mockCountries),
+    } as Response);
+
+    const result = await choicesService.getCountryChoices();
+
+    expect(result).toEqual(mockCountries);
+    expect(fetch).toHaveBeenCalledWith(
+      '/project_choices_data/countries.json',
+      expect.anything()
+    );
+  });
+
+  it('getLanguageChoices() fetches languages', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => 'application/json' },
+      text: async () => JSON.stringify(mockLanguages),
+    } as Response);
+
+    const result = await choicesService.getLanguageChoices();
+
+    expect(result).toEqual(mockLanguages);
+    expect(fetch).toHaveBeenCalledWith(
+      '/project_choices_data/languages.json',
+      expect.anything()
+    );
+  });
+});
+
+describe('choicesService - Cache Management', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    choicesService.clearCache();
+    vi.clearAllMocks();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('clearCache(type) clears specific choice type', async () => {
+    // Populate caches
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => 'application/json' },
+        text: async () => JSON.stringify(mockOccupations),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => 'application/json' },
+        text: async () => JSON.stringify(mockCountries),
+      } as Response);
+
+    await choicesService.getChoices('occupations');
+    await choicesService.getChoices('countries');
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+
+    // Clear only occupations
+    choicesService.clearCache('occupations');
+
+    // Mock new fetch for occupations
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => 'application/json' },
+      text: async () => JSON.stringify(mockOccupations),
+    } as Response);
+
+    // Occupations should fetch again, countries should use cache
+    await choicesService.getChoices('occupations');
+    await choicesService.getChoices('countries');
+
+    expect(fetch).toHaveBeenCalledTimes(3); // Only 1 new fetch for occupations
+  });
+
+  it('clearCache() with no argument clears all caches', async () => {
+    // Populate multiple caches
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => 'application/json' },
+        text: async () => JSON.stringify(mockOccupations),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => 'application/json' },
+        text: async () => JSON.stringify(mockCountries),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => 'application/json' },
+        text: async () => JSON.stringify(mockLanguages),
+      } as Response);
+
+    await choicesService.getChoices('occupations');
+    await choicesService.getChoices('countries');
+    await choicesService.getChoices('languages');
+
+    expect(fetch).toHaveBeenCalledTimes(3);
+
+    // Clear all caches
+    choicesService.clearCache();
+
+    // Mock fresh fetches
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => 'application/json' },
+        text: async () => JSON.stringify(mockOccupations),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => 'application/json' },
+        text: async () => JSON.stringify(mockCountries),
+      } as Response);
+
+    // All should fetch again
+    await choicesService.getChoices('occupations');
+    await choicesService.getChoices('countries');
+
+    expect(fetch).toHaveBeenCalledTimes(5); // 3 initial + 2 new
+  });
+
+  it('clearCache removes from both memory and localStorage', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => 'application/json' },
+      text: async () => JSON.stringify(mockOccupations),
+    } as Response);
+
+    await choicesService.getChoices('occupations');
+
+    // Verify both caches exist
+    expect(localStorage.getItem('edulite_choices_occupations_v1.0')).toBeTruthy();
+
+    choicesService.clearCache('occupations');
+
+    // Verify both caches cleared
+    expect(localStorage.getItem('edulite_choices_occupations_v1.0')).toBeNull();
+  });
+});
+
+describe('choicesService - Offline Support', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    choicesService.clearCache();
+    vi.clearAllMocks();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('hasOfflineChoices() returns true when data is cached', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => 'application/json' },
+      text: async () => JSON.stringify(mockOccupations),
+    } as Response);
+
+    await choicesService.getChoices('occupations');
+
+    expect(choicesService.hasOfflineChoices('occupations')).toBe(true);
+  });
+
+  it('hasOfflineChoices() returns false when no cache exists', () => {
+    expect(choicesService.hasOfflineChoices('countries')).toBe(false);
+  });
+
+  it('hasOfflineChoices() checks localStorage when memory cache empty', () => {
+    // Pre-populate localStorage
+    localStorage.setItem(
+      'edulite_choices_languages_v1.0',
+      JSON.stringify(mockLanguages)
+    );
+
+    // Memory cache is cold, but localStorage has data
+    expect(choicesService.hasOfflineChoices('languages')).toBe(true);
+  });
+
+  it('preloadAllChoices() loads all three choice types', async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => 'application/json' },
+        text: async () => JSON.stringify(mockOccupations),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => 'application/json' },
+        text: async () => JSON.stringify(mockCountries),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => 'application/json' },
+        text: async () => JSON.stringify(mockLanguages),
+      } as Response);
+
+    await choicesService.preloadAllChoices();
+
+    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(choicesService.hasOfflineChoices('occupations')).toBe(true);
+    expect(choicesService.hasOfflineChoices('countries')).toBe(true);
+    expect(choicesService.hasOfflineChoices('languages')).toBe(true);
+  });
+
+  it('preloadAllChoices() continues despite partial failures', async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => 'application/json' },
+        text: async () => JSON.stringify(mockOccupations),
+      } as Response)
+      .mockRejectedValueOnce(new Error('Network error')) // Countries fail
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => 'application/json' },
+        text: async () => JSON.stringify(mockLanguages),
+      } as Response);
+
+    await choicesService.preloadAllChoices();
+
+    // Should have attempted all 3
+    expect(fetch).toHaveBeenCalledTimes(3);
+
+    // Success caches should exist, failed one should not
+    expect(choicesService.hasOfflineChoices('occupations')).toBe(true);
+    expect(choicesService.hasOfflineChoices('countries')).toBe(false);
+    expect(choicesService.hasOfflineChoices('languages')).toBe(true);
+
+    // Note: Individual getChoices() calls catch their own errors and return []
+    // so Promise.all doesn't actually reject, and outer try-catch doesn't fire
+    // The failed request was logged by getChoices()'s internal error handler
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Error loading countries'),
+      expect.any(Error)
+    );
+  });
+});
+
+describe('choicesService - Edge Cases', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    choicesService.clearCache();
+    vi.clearAllMocks();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('handles concurrent requests for same choice type', async () => {
+    // Current implementation doesn't deduplicate concurrent requests
+    // Each racing request tries to fetch independently
+    // First one to complete populates the cache
+    // Others may fail to fetch (race lost) and return empty array
+
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      headers: { get: () => 'application/json' },
+      text: async () => JSON.stringify(mockOccupations),
+    } as Response);
+
+    // Make 3 concurrent requests
+    const promises = [
+      choicesService.getChoices('occupations'),
+      choicesService.getChoices('occupations'),
+      choicesService.getChoices('occupations'),
+    ];
+
+    const results = await Promise.all(promises);
+
+    // At least one should succeed and get cached data
+    const successfulResults = results.filter(r => r.length > 0);
+    expect(successfulResults.length).toBeGreaterThan(0);
+    expect(successfulResults[0]).toEqual(mockOccupations);
+
+    // After concurrent requests, cache should exist
+    expect(choicesService.hasOfflineChoices('occupations')).toBe(true);
+  });
+
+  it('handles empty array response as valid data', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => 'application/json' },
+      text: async () => JSON.stringify([]),
+    } as Response);
+
+    const result = await choicesService.getChoices('countries');
+
+    // Empty array is technically valid, but triggers warning
+    expect(result).toEqual([]);
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Suspiciously short'),
+      expect.anything()
+    );
+  });
+
+  it('respects cache versioning', () => {
+    // Old version cache
+    localStorage.setItem(
+      'edulite_choices_occupations_v0.9',
+      JSON.stringify(mockOccupations)
+    );
+
+    // Should not use old version
+    expect(choicesService.hasOfflineChoices('occupations')).toBe(false);
+  });
+});

--- a/Frontend/EduLiteFrontend/src/services/__tests__/tokenService.test.ts
+++ b/Frontend/EduLiteFrontend/src/services/__tests__/tokenService.test.ts
@@ -1,0 +1,577 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import axios from 'axios';
+import toast from 'react-hot-toast';
+import {
+  getStoredTokens,
+  setStoredTokens,
+  clearStoredTokens,
+  isTokenExpired,
+  refreshAccessToken,
+  getValidAccessToken,
+  setLogoutHandler,
+  setupAxiosInterceptors,
+  shouldBeAuthenticated,
+  initializeTokenService,
+} from '../tokenService';
+
+// Mock axios
+vi.mock('axios');
+const mockedAxios = vi.mocked(axios);
+
+// Mock react-hot-toast
+vi.mock('react-hot-toast', () => ({
+  default: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+/**
+ * JWT Token Generator Utility
+ * Creates valid/expired JWT tokens for testing
+ */
+const createJWT = (expiresInSeconds: number): string => {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = btoa(
+    JSON.stringify({
+      exp: Math.floor(Date.now() / 1000) + expiresInSeconds,
+      user_id: 1,
+      username: 'testuser',
+    })
+  );
+  return `${header}.${payload}.fake-signature`;
+};
+
+describe('tokenService - Storage Functions', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  describe('getStoredTokens', () => {
+    it('returns null tokens when storage is empty', () => {
+      const tokens = getStoredTokens();
+      expect(tokens).toEqual({ access: null, refresh: null });
+    });
+
+    it('returns tokens from storage', () => {
+      setStoredTokens('access-token', 'refresh-token');
+
+      const tokens = getStoredTokens();
+      expect(tokens).toEqual({
+        access: 'access-token',
+        refresh: 'refresh-token',
+      });
+    });
+  });
+
+  describe('setStoredTokens', () => {
+    it('stores tokens in storage', () => {
+      setStoredTokens('new-access', 'new-refresh');
+
+      // Verify tokens are retrievable
+      const tokens = getStoredTokens();
+      expect(tokens.access).toBe('new-access');
+      expect(tokens.refresh).toBe('new-refresh');
+    });
+
+    it('overwrites existing tokens', () => {
+      setStoredTokens('old-access', 'old-refresh');
+      setStoredTokens('new-access', 'new-refresh');
+
+      const tokens = getStoredTokens();
+      expect(tokens.access).toBe('new-access');
+      expect(tokens.refresh).toBe('new-refresh');
+    });
+  });
+
+  describe('clearStoredTokens', () => {
+    it('removes tokens from storage', () => {
+      setStoredTokens('access-token', 'refresh-token');
+      clearStoredTokens();
+
+      const tokens = getStoredTokens();
+      expect(tokens.access).toBeNull();
+      expect(tokens.refresh).toBeNull();
+    });
+
+    it('does not throw error when storage is already empty', () => {
+      expect(() => clearStoredTokens()).not.toThrow();
+    });
+  });
+});
+
+describe('tokenService - Token Validation', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  describe('isTokenExpired', () => {
+    it('returns true for empty string token', () => {
+      expect(isTokenExpired('')).toBe(true);
+    });
+
+    it('returns true for null/undefined token', () => {
+      expect(isTokenExpired(null as any)).toBe(true);
+      expect(isTokenExpired(undefined as any)).toBe(true);
+    });
+
+    it('returns true for malformed JWT (no dots)', () => {
+      expect(isTokenExpired('malformed-token')).toBe(true);
+    });
+
+    it('returns true for JWT with invalid base64 payload', () => {
+      expect(isTokenExpired('header.!!!invalid!!!.signature')).toBe(true);
+    });
+
+    it('returns false for valid non-expired token', () => {
+      const validToken = createJWT(3600); // Expires in 1 hour
+      expect(isTokenExpired(validToken)).toBe(false);
+    });
+
+    it('returns true for expired token', () => {
+      const expiredToken = createJWT(-3600); // Expired 1 hour ago
+      expect(isTokenExpired(expiredToken)).toBe(true);
+    });
+
+    it('returns true for token expiring within buffer time (30 seconds)', () => {
+      // Token expires in 20 seconds (within 30-second buffer)
+      const aboutToExpireToken = createJWT(20);
+      expect(isTokenExpired(aboutToExpireToken)).toBe(true);
+    });
+
+    it('returns false for token expiring after buffer time', () => {
+      // Token expires in 60 seconds (beyond 30-second buffer)
+      const validToken = createJWT(60);
+      expect(isTokenExpired(validToken)).toBe(false);
+    });
+
+    it('handles token with missing exp field', () => {
+      const header = btoa(JSON.stringify({ alg: 'HS256' }));
+      const payload = btoa(JSON.stringify({ user_id: 1 })); // No exp
+      const tokenWithoutExp = `${header}.${payload}.signature`;
+
+      // Missing exp means undefined < number = false, so token appears valid
+      // This is a quirk of the implementation - treats missing exp as "never expires"
+      expect(isTokenExpired(tokenWithoutExp)).toBe(false);
+    });
+  });
+
+  describe('shouldBeAuthenticated', () => {
+    it('returns false when no tokens in storage', () => {
+      expect(shouldBeAuthenticated()).toBe(false);
+    });
+
+    it('returns false when only access token exists', () => {
+      setStoredTokens(createJWT(3600), 'temp');
+      clearStoredTokens();
+      localStorage.setItem('access', createJWT(3600));
+      expect(shouldBeAuthenticated()).toBe(false);
+    });
+
+    it('returns false when only refresh token exists', () => {
+      localStorage.setItem('refresh', createJWT(3600));
+      expect(shouldBeAuthenticated()).toBe(false);
+    });
+
+    it('returns true when both tokens exist and refresh is valid', () => {
+      setStoredTokens(createJWT(3600), createJWT(3600));
+      expect(shouldBeAuthenticated()).toBe(true);
+    });
+
+    it('returns false and clears tokens when refresh token is expired', () => {
+      setStoredTokens(createJWT(3600), createJWT(-3600)); // Expired refresh
+
+      expect(shouldBeAuthenticated()).toBe(false);
+
+      const tokens = getStoredTokens();
+      expect(tokens.access).toBeNull();
+      expect(tokens.refresh).toBeNull();
+    });
+
+    it('returns true even if access token is expired (as long as refresh is valid)', () => {
+      setStoredTokens(createJWT(-100), createJWT(3600)); // Expired access, valid refresh
+
+      expect(shouldBeAuthenticated()).toBe(true);
+    });
+  });
+});
+
+describe('tokenService - Token Refresh', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  describe('refreshAccessToken', () => {
+    it('throws error when no refresh token in storage', async () => {
+      await expect(refreshAccessToken()).rejects.toThrow(/refresh token|Failed to refresh/i);
+    });
+
+    it('throws error when refresh token is expired', async () => {
+      setStoredTokens('access', createJWT(-3600)); // Expired refresh
+
+      await expect(refreshAccessToken()).rejects.toThrow('Refresh token expired');
+    });
+
+    it('successfully refreshes access token', async () => {
+      const refreshToken = createJWT(3600);
+      const newAccessToken = createJWT(3600);
+      setStoredTokens('old-access', refreshToken);
+
+      mockedAxios.post.mockResolvedValueOnce({
+        data: { access: newAccessToken },
+      });
+
+      const result = await refreshAccessToken();
+
+      expect(result).toBe(newAccessToken);
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        expect.stringContaining('/token/refresh/'),
+        { refresh: refreshToken },
+        {
+          headers: { 'Content-Type': 'application/json' },
+          timeout: 10000,
+        }
+      );
+
+      // Verify new token was stored
+      const tokens = getStoredTokens();
+      expect(tokens.access).toBe(newAccessToken);
+    });
+
+    it('clears tokens on 401 response', async () => {
+      setStoredTokens(createJWT(3600), createJWT(3600));
+
+      mockedAxios.post.mockRejectedValueOnce({
+        response: { status: 401 },
+      });
+
+      await expect(refreshAccessToken()).rejects.toThrow('Refresh token expired or invalid');
+
+      const tokens = getStoredTokens();
+      expect(tokens.access).toBeNull();
+      expect(tokens.refresh).toBeNull();
+    });
+
+    it('clears tokens on network error', async () => {
+      setStoredTokens(createJWT(3600), createJWT(3600));
+
+      mockedAxios.post.mockRejectedValueOnce(new Error('Network error'));
+
+      await expect(refreshAccessToken()).rejects.toThrow('Failed to refresh access token');
+
+      const tokens = getStoredTokens();
+      expect(tokens.access).toBeNull();
+      expect(tokens.refresh).toBeNull();
+    });
+  });
+
+  describe('getValidAccessToken', () => {
+    it('throws error when no tokens exist', async () => {
+      await expect(getValidAccessToken()).rejects.toThrow('No authentication tokens available');
+    });
+
+    it('returns access token directly when not expired', async () => {
+      const validAccessToken = createJWT(3600);
+      setStoredTokens(validAccessToken, createJWT(3600));
+
+      const result = await getValidAccessToken();
+
+      expect(result).toBe(validAccessToken);
+      expect(mockedAxios.post).not.toHaveBeenCalled(); // No refresh needed
+    });
+
+    it('refreshes and returns new token when access token is expired', async () => {
+      const expiredAccessToken = createJWT(-100);
+      const newAccessToken = createJWT(3600);
+      setStoredTokens(expiredAccessToken, createJWT(3600));
+
+      mockedAxios.post.mockResolvedValueOnce({
+        data: { access: newAccessToken },
+      });
+
+      const result = await getValidAccessToken();
+
+      expect(result).toBe(newAccessToken);
+      expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+    });
+
+    it('queues concurrent requests during refresh', async () => {
+      const expiredAccessToken = createJWT(-100);
+      const newAccessToken = createJWT(3600);
+      setStoredTokens(expiredAccessToken, createJWT(3600));
+
+      // Simulate slow refresh
+      mockedAxios.post.mockImplementation(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(() => resolve({ data: { access: newAccessToken } }), 100)
+          )
+      );
+
+      // Make 3 concurrent requests
+      const promises = [getValidAccessToken(), getValidAccessToken(), getValidAccessToken()];
+
+      const results = await Promise.all(promises);
+
+      // All should receive the same new token
+      expect(results).toEqual([newAccessToken, newAccessToken, newAccessToken]);
+      // But refresh should only happen once
+      expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+    });
+
+    it('propagates error to queued requests when refresh fails', async () => {
+      const expiredAccessToken = createJWT(-100);
+      setStoredTokens(expiredAccessToken, createJWT(3600));
+
+      mockedAxios.post.mockRejectedValueOnce(new Error('Refresh failed'));
+
+      const promises = [getValidAccessToken(), getValidAccessToken(), getValidAccessToken()];
+
+      await expect(Promise.all(promises)).rejects.toThrow(/failed|refresh/i);
+    });
+  });
+});
+
+describe('tokenService - Setup & Handlers', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  describe('setLogoutHandler', () => {
+    it('registers logout handler callback', () => {
+      const logoutHandler = vi.fn();
+      setLogoutHandler(logoutHandler);
+
+      // We can't directly test the handler is set, but we'll test it via interceptor tests
+      expect(logoutHandler).toBeDefined();
+    });
+  });
+
+  describe('initializeTokenService', () => {
+    it('sets up axios interceptors', () => {
+      const interceptorsSpy = vi.spyOn(axios.interceptors.request, 'use');
+
+      initializeTokenService();
+
+      expect(interceptorsSpy).toHaveBeenCalled();
+    });
+  });
+});
+
+describe('tokenService - Axios Interceptors', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+
+    // Mock axios interceptors
+    mockedAxios.interceptors = {
+      request: { use: vi.fn(), eject: vi.fn() },
+      response: { use: vi.fn(), eject: vi.fn() },
+    } as any;
+  });
+
+  describe('Request Interceptor', () => {
+    it('adds Authorization header to requests with valid token', async () => {
+      const validAccessToken = createJWT(3600);
+      setStoredTokens(validAccessToken, createJWT(3600));
+
+      setupAxiosInterceptors();
+
+      // Get the request interceptor callback
+      const requestInterceptor = (mockedAxios.interceptors.request.use as any).mock.calls[0][0];
+
+      const config = {
+        url: '/api/profile/',
+        headers: {},
+      };
+
+      const result = await requestInterceptor(config);
+
+      expect(result.headers.Authorization).toBe(`Bearer ${validAccessToken}`);
+    });
+
+    it('skips token injection for /token/ endpoints', async () => {
+      setupAxiosInterceptors();
+
+      const requestInterceptor = (mockedAxios.interceptors.request.use as any).mock.calls[0][0];
+
+      const config = {
+        url: '/api/token/refresh/',
+        headers: {},
+      };
+
+      const result = await requestInterceptor(config);
+
+      expect(result.headers.Authorization).toBeUndefined();
+    });
+
+    it('skips token injection for /register/ endpoints', async () => {
+      setupAxiosInterceptors();
+
+      const requestInterceptor = (mockedAxios.interceptors.request.use as any).mock.calls[0][0];
+
+      const config = {
+        url: '/api/register/',
+        headers: {},
+      };
+
+      const result = await requestInterceptor(config);
+
+      expect(result.headers.Authorization).toBeUndefined();
+    });
+
+    it('does not block request when token retrieval fails', async () => {
+      // Ensure no tokens exist by clearing and not setting any
+      clearStoredTokens();
+
+      setupAxiosInterceptors();
+
+      const requestInterceptor = (mockedAxios.interceptors.request.use as any).mock.calls[0][0];
+
+      const config = {
+        url: '/api/profile/',
+        headers: {},
+      };
+
+      const result = await requestInterceptor(config);
+
+      // Request should still proceed without token
+      expect(result).toBeDefined();
+      expect(result.headers.Authorization).toBeUndefined();
+    });
+  });
+
+  describe('Response Interceptor', () => {
+    it('returns response directly on success', async () => {
+      setupAxiosInterceptors();
+
+      const responseInterceptor = (mockedAxios.interceptors.response.use as any).mock.calls[0][0];
+
+      const response = {
+        data: { message: 'success' },
+        status: 200,
+      };
+
+      const result = await responseInterceptor(response);
+
+      expect(result).toBe(response);
+    });
+
+    it('does not retry auth endpoints on 401', async () => {
+      setupAxiosInterceptors();
+
+      const errorInterceptor = (mockedAxios.interceptors.response.use as any).mock.calls[0][1];
+
+      const error = {
+        response: { status: 401 },
+        config: { url: '/api/token/refresh/' },
+      };
+
+      await expect(errorInterceptor(error)).rejects.toEqual(error);
+      expect(mockedAxios.post).not.toHaveBeenCalled();
+    });
+
+    it('retries request with new token on 401 after successful refresh', async () => {
+      const expiredAccessToken = createJWT(-100);
+      const newAccessToken = createJWT(3600);
+      setStoredTokens(expiredAccessToken, createJWT(3600));
+
+      mockedAxios.post.mockResolvedValueOnce({
+        data: { access: newAccessToken },
+      });
+
+      mockedAxios.mockResolvedValueOnce({
+        data: { message: 'success after retry' },
+      });
+
+      setupAxiosInterceptors();
+
+      const errorInterceptor = (mockedAxios.interceptors.response.use as any).mock.calls[0][1];
+
+      const error = {
+        response: { status: 401 },
+        config: {
+          url: '/api/profile/',
+          headers: {},
+          _retry: false,
+        },
+      };
+
+      const result = await errorInterceptor(error);
+
+      expect(error.config.headers.Authorization).toBe(`Bearer ${newAccessToken}`);
+      expect(mockedAxios).toHaveBeenCalledWith(error.config);
+    });
+
+    it('calls logout handler when refresh fails on 401', async () => {
+      const logoutHandler = vi.fn();
+      setLogoutHandler(logoutHandler);
+
+      setStoredTokens(createJWT(-100), createJWT(3600));
+
+      mockedAxios.post.mockRejectedValueOnce(new Error('Refresh failed'));
+
+      setupAxiosInterceptors();
+
+      const errorInterceptor = (mockedAxios.interceptors.response.use as any).mock.calls[0][1];
+
+      const error = {
+        response: { status: 401 },
+        config: {
+          url: '/api/profile/',
+          headers: {},
+        },
+      };
+
+      await expect(errorInterceptor(error)).rejects.toThrow();
+
+      // Wait for async operations
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      expect(logoutHandler).toHaveBeenCalledTimes(1);
+      expect(toast.error).toHaveBeenCalledWith('Session expired. Please log in again.');
+    });
+
+    it('does not show multiple logout toasts for concurrent failures', async () => {
+      const logoutHandler = vi.fn();
+      setLogoutHandler(logoutHandler);
+
+      setStoredTokens(createJWT(-100), createJWT(3600));
+
+      mockedAxios.post.mockRejectedValue(new Error('Refresh failed'));
+
+      setupAxiosInterceptors();
+
+      const errorInterceptor = (mockedAxios.interceptors.response.use as any).mock.calls[0][1];
+
+      const errors = [
+        {
+          response: { status: 401 },
+          config: { url: '/api/profile/', headers: {} },
+        },
+        {
+          response: { status: 401 },
+          config: { url: '/api/courses/', headers: {} },
+        },
+        {
+          response: { status: 401 },
+          config: { url: '/api/assignments/', headers: {} },
+        },
+      ];
+
+      await Promise.allSettled(errors.map((error) => errorInterceptor(error)));
+
+      // Wait for async operations
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      // Should only show toast once despite 3 failed requests
+      expect(toast.error).toHaveBeenCalledTimes(1);
+      expect(logoutHandler).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/Frontend/EduLiteFrontend/src/services/__tests__/tokenService.test.ts
+++ b/Frontend/EduLiteFrontend/src/services/__tests__/tokenService.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import axios from 'axios';
 import toast from 'react-hot-toast';
 import {
@@ -16,7 +16,7 @@ import {
 
 // Mock axios
 vi.mock('axios');
-const mockedAxios = vi.mocked(axios);
+const mockedAxios = vi.mocked(axios, { deep: true });
 
 // Mock react-hot-toast
 vi.mock('react-hot-toast', () => ({
@@ -497,12 +497,12 @@ describe('tokenService - Axios Interceptors', () => {
         response: { status: 401 },
         config: {
           url: '/api/profile/',
-          headers: {},
+          headers: {} as Record<string, string>,
           _retry: false,
         },
       };
 
-      const result = await errorInterceptor(error);
+      await errorInterceptor(error);
 
       expect(error.config.headers.Authorization).toBe(`Bearer ${newAccessToken}`);
       expect(mockedAxios).toHaveBeenCalledWith(error.config);

--- a/Frontend/EduLiteFrontend/src/test/setup.ts
+++ b/Frontend/EduLiteFrontend/src/test/setup.ts
@@ -1,0 +1,11 @@
+import { expect, afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import * as matchers from '@testing-library/jest-dom/matchers';
+
+// Extend Vitest's expect with jest-dom matchers
+expect.extend(matchers);
+
+// Cleanup after each test
+afterEach(() => {
+  cleanup();
+});

--- a/Frontend/EduLiteFrontend/src/test/utils.tsx
+++ b/Frontend/EduLiteFrontend/src/test/utils.tsx
@@ -1,0 +1,43 @@
+import React, { ReactElement } from 'react';
+import { render, RenderOptions } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { AuthProvider } from '../contexts/AuthContext';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '../i18n';
+
+/**
+ * Custom render function that wraps components with necessary providers
+ * for testing. This includes Router, Auth, and i18n contexts.
+ *
+ * @example
+ * import { renderWithProviders } from '@/test/utils';
+ *
+ * test('renders component', () => {
+ *   renderWithProviders(<MyComponent />);
+ *   // assertions...
+ * });
+ */
+interface AllTheProvidersProps {
+  children: React.ReactNode;
+}
+
+const AllTheProviders: React.FC<AllTheProvidersProps> = ({ children }) => {
+  return (
+    <BrowserRouter>
+      <I18nextProvider i18n={i18n}>
+        <AuthProvider>
+          {children}
+        </AuthProvider>
+      </I18nextProvider>
+    </BrowserRouter>
+  );
+};
+
+const customRender = (
+  ui: ReactElement,
+  options?: Omit<RenderOptions, 'wrapper'>
+) => render(ui, { wrapper: AllTheProviders, ...options });
+
+// Re-export everything from React Testing Library
+export * from '@testing-library/react';
+export { customRender as renderWithProviders };

--- a/Frontend/EduLiteFrontend/src/test/vitest-env.d.ts
+++ b/Frontend/EduLiteFrontend/src/test/vitest-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vitest" />
+/// <reference types="@testing-library/jest-dom" />
+
+import type { TestingLibraryMatchers } from '@testing-library/jest-dom/matchers';
+
+declare module 'vitest' {
+  interface Assertion<T = any> extends jest.Matchers<void, T>, TestingLibraryMatchers<T, void> {}
+  interface AsymmetricMatchersContaining extends jest.Matchers<void, any> {}
+}

--- a/Frontend/EduLiteFrontend/tsconfig.json
+++ b/Frontend/EduLiteFrontend/tsconfig.json
@@ -20,7 +20,8 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "types": ["vitest/globals"]
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/Frontend/EduLiteFrontend/vite.config.js
+++ b/Frontend/EduLiteFrontend/vite.config.js
@@ -4,4 +4,31 @@ import tailwindcss from '@tailwindcss/vite'
 
 export default defineConfig({
   plugins: [react() , tailwindcss() ],
+  resolve: {
+    alias: {
+      '@': '/src',
+    },
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/test/setup.ts',
+    css: true,
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        singleFork: true,
+      },
+    },
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      exclude: [
+        'node_modules/',
+        'src/test/',
+        '**/*.test.{ts,tsx,js,jsx}',
+        '**/*.spec.{ts,tsx,js,jsx}',
+      ],
+    },
+  },
 })


### PR DESCRIPTION
# Add Vitest Testing Framework

Closes #175

## Summary
- Implemented Vitest testing framework with React Testing Library
- 229 tests across 8 test files, 100% passing
- 0 TypeScript errors

## Test Coverage
- **Components**: Button, Input (including edge cases)
- **Pages**: NotFoundPage
- **Services**: tokenService (JWT/auth), choicesService (caching)

## Configuration
- Vitest v3.2.4 with jsdom environment
- Custom test utilities with provider wrappers
- TypeScript declarations for jest-dom matchers

## Test Scripts
```bash
npm test           # Run all tests
npm run test:watch # Watch mode
npm run test:ui    # UI mode
npm run test:coverage # Coverage report
```