### PR TITLE
add types

### DIFF
--- a/Frontend/EduLiteFrontend/src/services/slideshowApi.ts
+++ b/Frontend/EduLiteFrontend/src/services/slideshowApi.ts
@@ -1,0 +1,292 @@
+import axios, { AxiosError } from "axios";
+import type {
+  SlideshowListItem,
+  SlideshowDetail,
+  SlideshowCreateRequest,
+  SlideshowUpdateRequest,
+  SlideshowListParams,
+  PaginatedResponse,
+  VersionConflictError,
+  Slide,
+  SlideViewOnly,
+  SlideshowErrorResponse,
+} from "../types/slideshow.types";
+
+const API_BASE_URL = "http://localhost:8000/api";
+
+// Note: Authorization headers are handled automatically by axios interceptors in tokenService.ts
+
+/**
+ * List all visible slideshows
+ * Returns paginated results with current user's own slideshows + published public ones
+ *
+ * @param params - Optional filter parameters (visibility, subject, language, country, mine, pagination)
+ * @returns Paginated list of slideshows
+ */
+export const listSlideshows = async (
+  params?: SlideshowListParams
+): Promise<PaginatedResponse<SlideshowListItem>> => {
+  try {
+    const response = await axios.get(`${API_BASE_URL}/slideshows/`, {
+      params,
+      timeout: 10000,
+    });
+    return response.data;
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      throw new Error(
+        error.response?.data?.detail || "Failed to fetch slideshows"
+      );
+    }
+    throw error;
+  }
+};
+
+/**
+ * Get only the current user's slideshows
+ * Convenience function that sets mine=true
+ *
+ * @param params - Optional additional filter parameters
+ * @returns Paginated list of user's slideshows
+ */
+export const listMySlideshows = async (
+  params?: Omit<SlideshowListParams, "mine">
+): Promise<PaginatedResponse<SlideshowListItem>> => {
+  return listSlideshows({ ...params, mine: true });
+};
+
+/**
+ * Get detailed slideshow information
+ * Supports progressive loading via initialSlideCount parameter
+ *
+ * @param id - Slideshow ID
+ * @param initialSlideCount - Optional: load only first N slides, get remaining IDs for background fetching
+ * @returns Full slideshow detail with slides
+ */
+export const getSlideshowDetail = async (
+  id: number,
+  initialSlideCount?: number
+): Promise<SlideshowDetail> => {
+  try {
+    const params = initialSlideCount ? { initial: initialSlideCount } : {};
+    const response = await axios.get(`${API_BASE_URL}/slideshows/${id}/`, {
+      params,
+      timeout: 10000,
+    });
+    return response.data;
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      if (error.response?.status === 404) {
+        throw new Error("Slideshow not found");
+      }
+      if (error.response?.status === 403) {
+        throw new Error("You don't have permission to view this slideshow");
+      }
+      throw new Error(
+        error.response?.data?.detail || "Failed to fetch slideshow"
+      );
+    }
+    throw error;
+  }
+};
+
+/**
+ * Get a single slide by ID
+ * Used for progressive loading - fetch individual slides in background
+ *
+ * @param slideshowId - Slideshow ID
+ * @param slideId - Slide ID
+ * @returns Single slide data
+ */
+export const getSlide = async (
+  slideshowId: number,
+  slideId: number
+): Promise<Slide | SlideViewOnly> => {
+  try {
+    const response = await axios.get(
+      `${API_BASE_URL}/slideshows/${slideshowId}/slides/${slideId}/`,
+      {
+        timeout: 10000,
+      }
+    );
+    return response.data;
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      if (error.response?.status === 404) {
+        throw new Error("Slide not found");
+      }
+      throw new Error(error.response?.data?.detail || "Failed to fetch slide");
+    }
+    throw error;
+  }
+};
+
+/**
+ * Create a new slideshow
+ * Can optionally include nested slides in the creation request
+ *
+ * @param data - Slideshow creation data
+ * @returns Created slideshow detail
+ */
+export const createSlideshow = async (
+  data: SlideshowCreateRequest
+): Promise<SlideshowDetail> => {
+  try {
+    const response = await axios.post(`${API_BASE_URL}/slideshows/`, data, {
+      timeout: 15000, // Longer timeout for creation with nested slides
+    });
+    return response.data;
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      if (error.response?.status === 400) {
+        const errorData = error.response?.data as SlideshowErrorResponse;
+        // Handle field-specific errors
+        if (errorData?.title) {
+          throw new Error(`Title: ${Array.isArray(errorData.title) ? errorData.title[0] : errorData.title}`);
+        }
+        if (errorData?.slides) {
+          throw new Error(`Slides: ${Array.isArray(errorData.slides) ? errorData.slides[0] : errorData.slides}`);
+        }
+        throw new Error(errorData?.detail || "Invalid slideshow data");
+      }
+      throw new Error(
+        error.response?.data?.detail || "Failed to create slideshow"
+      );
+    }
+    throw error;
+  }
+};
+
+/**
+ * Update an existing slideshow
+ * Must include version number - server returns 409 if version conflicts
+ *
+ * @param id - Slideshow ID
+ * @param data - Update data including version number
+ * @returns Updated slideshow detail
+ * @throws VersionConflictError if version is stale (HTTP 409)
+ */
+export const updateSlideshow = async (
+  id: number,
+  data: SlideshowUpdateRequest
+): Promise<SlideshowDetail> => {
+  try {
+    const response = await axios.patch(
+      `${API_BASE_URL}/slideshows/${id}/`,
+      data,
+      {
+        timeout: 15000,
+      }
+    );
+    return response.data;
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      if (error.response?.status === 409) {
+        // Version conflict - throw the conflict details
+        const conflictData = error.response?.data as VersionConflictError;
+        throw {
+          isVersionConflict: true,
+          ...conflictData,
+        } as VersionConflictError & { isVersionConflict: true };
+      }
+      if (error.response?.status === 400) {
+        const errorData = error.response?.data as SlideshowErrorResponse;
+        // Check if this is a version conflict disguised as 400
+        if (errorData?.error === "version_conflict") {
+          throw {
+            isVersionConflict: true,
+            ...errorData,
+          } as VersionConflictError & { isVersionConflict: true };
+        }
+        throw new Error(errorData?.detail || "Invalid update data");
+      }
+      if (error.response?.status === 403) {
+        throw new Error("You don't have permission to update this slideshow");
+      }
+      if (error.response?.status === 404) {
+        throw new Error("Slideshow not found");
+      }
+      throw new Error(
+        error.response?.data?.detail || "Failed to update slideshow"
+      );
+    }
+    throw error;
+  }
+};
+
+/**
+ * Delete a slideshow (owner only)
+ *
+ * @param id - Slideshow ID
+ */
+export const deleteSlideshow = async (id: number): Promise<void> => {
+  try {
+    await axios.delete(`${API_BASE_URL}/slideshows/${id}/`, {
+      timeout: 10000,
+    });
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      if (error.response?.status === 403) {
+        throw new Error("You don't have permission to delete this slideshow");
+      }
+      if (error.response?.status === 404) {
+        throw new Error("Slideshow not found");
+      }
+      throw new Error(
+        error.response?.data?.detail || "Failed to delete slideshow"
+      );
+    }
+    throw error;
+  }
+};
+
+/**
+ * Type guard to check if an error is a version conflict
+ *
+ * @param error - Any error object
+ * @returns True if error is a version conflict
+ */
+export const isVersionConflictError = (
+  error: any
+): error is VersionConflictError & { isVersionConflict: true } => {
+  return (
+    error?.isVersionConflict === true ||
+    (error?.error === "version_conflict" &&
+      typeof error?.server_version === "number" &&
+      typeof error?.client_version === "number")
+  );
+};
+
+/**
+ * Extract version conflict details from error
+ * Returns null if not a version conflict
+ *
+ * @param error - Error object from API call
+ * @returns Conflict details or null
+ */
+export const getVersionConflictDetails = (
+  error: any
+): VersionConflictError | null => {
+  if (isVersionConflictError(error)) {
+    return {
+      error: "version_conflict",
+      message: error.message || "Slideshow was modified since you loaded it",
+      server_version: error.server_version,
+      client_version: error.client_version,
+    };
+  }
+  return null;
+};
+
+// Export types for use in components
+export type {
+  SlideshowListItem,
+  SlideshowDetail,
+  SlideshowCreateRequest,
+  SlideshowUpdateRequest,
+  SlideshowListParams,
+  PaginatedResponse,
+  VersionConflictError,
+  Slide,
+  SlideViewOnly,
+};

--- a/Frontend/EduLiteFrontend/src/types/slideshow.types.ts
+++ b/Frontend/EduLiteFrontend/src/types/slideshow.types.ts
@@ -1,0 +1,172 @@
+// Slideshow-related TypeScript type definitions
+
+/**
+ * Visibility options for slideshows
+ * - public: Discoverable and viewable by anyone (if published)
+ * - unlisted: Not discoverable, but viewable with direct link (if published)
+ * - private: Only the owner can view
+ */
+export type SlideshowVisibility = "public" | "unlisted" | "private";
+
+/**
+ * Individual slide within a slideshow
+ * Full version with all fields (for owners)
+ */
+export interface Slide {
+  id: number;
+  order: number;
+  title: string | null;
+  content: string; // Raw markdown (owner only)
+  rendered_content: string; // HTML rendered from markdown
+  notes: string | null; // Speaker notes (owner only)
+  created_at: string; // ISO date string
+  updated_at: string; // ISO date string
+}
+
+/**
+ * Slide view for non-owners
+ * Does not include raw content or speaker notes
+ */
+export interface SlideViewOnly {
+  id: number;
+  order: number;
+  title: string | null;
+  rendered_content: string; // HTML rendered from markdown
+  created_at: string; // ISO date string
+  updated_at: string; // ISO date string
+}
+
+/**
+ * Lightweight slideshow for list views
+ * Does not include nested slides - only metadata
+ */
+export interface SlideshowListItem {
+  id: number;
+  title: string;
+  description: string | null;
+  created_by: number;
+  created_by_username: string;
+  visibility: SlideshowVisibility;
+  language: string | null; // Language code like 'en', 'ar', 'es'
+  country: string | null; // Country code like 'US', 'PS', 'AF'
+  subject: string | null; // Subject code like 'cs', 'math', 'science'
+  is_published: boolean;
+  slide_count: number;
+  version: number;
+  created_at: string; // ISO date string
+  updated_at: string; // ISO date string
+}
+
+/**
+ * Full slideshow detail with nested slides
+ * Supports progressive loading via 'initial' parameter
+ */
+export interface SlideshowDetail {
+  id: number;
+  title: string;
+  description: string | null;
+  created_by: number;
+  created_by_username: string;
+  visibility: SlideshowVisibility;
+  language: string | null;
+  country: string | null;
+  subject: string | null;
+  is_published: boolean;
+  version: number;
+  slide_count: number;
+  slides: Slide[] | SlideViewOnly[]; // Depends on ownership
+  remaining_slide_ids: number[]; // IDs of slides not yet loaded (for progressive loading)
+  created_at: string; // ISO date string
+  updated_at: string; // ISO date string
+}
+
+/**
+ * Request payload for creating a new slideshow
+ * Slides are optional - can be added later
+ */
+export interface SlideshowCreateRequest {
+  title: string;
+  description?: string | null;
+  visibility?: SlideshowVisibility;
+  language?: string | null;
+  country?: string | null;
+  subject?: string | null;
+  is_published?: boolean;
+  slides?: SlideCreateData[];
+}
+
+/**
+ * Slide data for creation (nested within slideshow)
+ */
+export interface SlideCreateData {
+  order?: number; // Auto-assigned if not provided
+  title?: string | null;
+  content: string; // Raw markdown
+  notes?: string | null;
+}
+
+/**
+ * Request payload for updating a slideshow
+ * Must include version number for conflict detection
+ */
+export interface SlideshowUpdateRequest {
+  title?: string;
+  description?: string | null;
+  visibility?: SlideshowVisibility;
+  language?: string | null;
+  country?: string | null;
+  subject?: string | null;
+  is_published?: boolean;
+  version: number; // Required for conflict detection
+  slides?: SlideCreateData[]; // Optional - if provided, replaces all existing slides
+}
+
+/**
+ * Query parameters for filtering slideshow list
+ */
+export interface SlideshowListParams {
+  mine?: boolean; // If true, only return current user's slideshows
+  visibility?: SlideshowVisibility; // Filter by visibility
+  subject?: string; // Filter by subject code
+  language?: string; // Filter by language code
+  country?: string; // Filter by country code
+  search?: string; // Search in title/description
+  page?: number; // Page number for pagination
+  page_size?: number; // Results per page
+}
+
+/**
+ * Paginated response wrapper (Django REST Framework format)
+ */
+export interface PaginatedResponse<T> {
+  count: number; // Total number of results
+  next: string | null; // URL to next page
+  previous: string | null; // URL to previous page
+  results: T[]; // Array of results
+}
+
+/**
+ * Version conflict error response (HTTP 409)
+ * Returned when client tries to update with stale version
+ */
+export interface VersionConflictError {
+  error: "version_conflict";
+  message: string;
+  server_version: number;
+  client_version: number;
+}
+
+/**
+ * Generic backend error response structure
+ */
+export interface SlideshowErrorResponse {
+  detail?: string;
+  error?: string;
+  message?: string;
+  // Field-specific errors
+  title?: string | string[];
+  description?: string | string[];
+  visibility?: string | string[];
+  slides?: string | string[];
+  non_field_errors?: string | string[];
+}

--- a/backend/EduLite/mercury_report_20251220_233233.html
+++ b/backend/EduLite/mercury_report_20251220_233233.html
@@ -1,0 +1,713 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mercury Performance Test Summary - 2025-12-20 23:32:33</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+            padding: 40px 20px;
+        }
+
+        .container {
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .card {
+            background: white;
+            border-radius: 12px;
+            padding: 30px;
+            margin-bottom: 24px;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+        }
+
+        h1 {
+            color: #1a202c;
+            font-size: 36px;
+            margin-bottom: 12px;
+        }
+
+        h2 {
+            color: #2d3748;
+            font-size: 24px;
+            margin-bottom: 20px;
+            border-bottom: 2px solid #e2e8f0;
+            padding-bottom: 10px;
+        }
+
+        h3 {
+            color: #4a5568;
+            font-size: 18px;
+            margin: 16px 0 12px 0;
+        }
+
+        .header {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            text-align: center;
+        }
+
+        .header h1 {
+            color: white;
+        }
+
+        .timestamp {
+            color: rgba(255, 255, 255, 0.9);
+            font-size: 14px;
+            margin-top: 8px;
+        }
+
+        .stats-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 20px;
+            margin-top: 20px;
+        }
+
+        .stat {
+            background: #f7fafc;
+            padding: 20px;
+            border-radius: 8px;
+            text-align: center;
+            border-left: 4px solid #cbd5e0;
+        }
+
+        .stat.pass {
+            border-left-color: #48bb78;
+        }
+
+        .stat.fail {
+            border-left-color: #f56565;
+        }
+
+        .stat-label {
+            color: #718096;
+            font-size: 13px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            margin-bottom: 8px;
+        }
+
+        .stat-value {
+            font-size: 32px;
+            font-weight: 700;
+            color: #1a202c;
+        }
+
+        .stat-value.pass {
+            color: #38a169;
+        }
+
+        .stat-value.fail {
+            color: #e53e3e;
+        }
+
+        .test-list {
+            list-style: none;
+        }
+
+        .test-item {
+            background: #f7fafc;
+            padding: 16px;
+            margin-bottom: 12px;
+            border-radius: 8px;
+            border-left: 4px solid #cbd5e0;
+        }
+
+        .test-item.pass {
+            border-left-color: #48bb78;
+        }
+
+        .test-item.fail {
+            border-left-color: #f56565;
+        }
+
+        .test-name {
+            font-weight: 600;
+            color: #2d3748;
+            margin-bottom: 6px;
+        }
+
+        .test-name.pass::before {
+            content: "✓ ";
+            color: #38a169;
+            font-weight: 700;
+        }
+
+        .test-name.fail::before {
+            content: "✗ ";
+            color: #e53e3e;
+            font-weight: 700;
+        }
+
+        .test-metrics {
+            color: #718096;
+            font-size: 14px;
+        }
+
+        .test-metrics span {
+            margin-right: 16px;
+        }
+
+        .badge {
+            display: inline-block;
+            padding: 3px 10px;
+            border-radius: 12px;
+            font-size: 11px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.3px;
+        }
+
+        .badge.n1 {
+            background: #fed7d7;
+            color: #742a2a;
+        }
+
+        .badge.slow {
+            background: #fef5e7;
+            color: #7d6608;
+        }
+
+        details {
+            margin-bottom: 12px;
+        }
+
+        summary {
+            cursor: pointer;
+            padding: 12px;
+            background: #f7fafc;
+            border-radius: 6px;
+            font-weight: 600;
+            color: #2d3748;
+            user-select: none;
+        }
+
+        summary:hover {
+            background: #edf2f7;
+        }
+
+        .detail-content {
+            padding: 16px;
+            margin-top: 8px;
+            background: #ffffff;
+            border-left: 3px solid #e2e8f0;
+        }
+
+        .pattern-summary {
+            background: #fff5f5;
+            border-left: 4px solid #fc8181;
+            padding: 16px;
+            margin-bottom: 16px;
+            border-radius: 6px;
+        }
+
+        .pattern-query {
+            font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+            font-size: 13px;
+            color: #2d3748;
+            background: white;
+            padding: 10px;
+            border-radius: 4px;
+            margin: 8px 0;
+            overflow-x: auto;
+        }
+
+        .pattern-tests {
+            margin-top: 10px;
+            font-size: 13px;
+            color: #718096;
+        }
+
+        .footer {
+            text-align: center;
+            color: white;
+            font-size: 13px;
+            margin-top: 40px;
+            opacity: 0.9;
+        }
+
+        .footer a {
+            color: white;
+            text-decoration: underline;
+        }
+
+        .progress-bar {
+            width: 100%;
+            height: 8px;
+            background: #e2e8f0;
+            border-radius: 4px;
+            overflow: hidden;
+            margin: 8px 0;
+        }
+
+        .progress-fill {
+            height: 100%;
+            background: #48bb78;
+            transition: width 0.3s ease;
+        }
+
+        .progress-fill.fail {
+            background: #f56565;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <!-- Header -->
+        <div class="card header">
+            <h1>⚡ Mercury Performance Test Summary</h1>
+            <div class="timestamp">Generated: 2025-12-20 23:32:33</div>
+        </div>
+
+        <!-- Dashboard Stats -->
+        <div class="card">
+            <h2>Test Run Statistics</h2>
+            <div class="stats-grid">
+                <div class="stat">
+                    <div class="stat-label">Total Tests</div>
+                    <div class="stat-value">15</div>
+                </div>
+                <div class="stat pass">
+                    <div class="stat-label">Passed</div>
+                    <div class="stat-value pass">15</div>
+                    <div class="progress-bar">
+                        <div class="progress-fill" style="width: 100.0%"></div>
+                    </div>
+                </div>
+                <div class="stat fail">
+                    <div class="stat-label">Failed</div>
+                    <div class="stat-value fail">0</div>
+                    <div class="progress-bar">
+                        <div class="progress-fill fail" style="width: 0.0%"></div>
+                    </div>
+                </div>
+                <div class="stat">
+                    <div class="stat-label">Avg Response Time</div>
+                    <div class="stat-value">10.8<small style="font-size: 16px;">ms</small></div>
+                </div>
+                <div class="stat">
+                    <div class="stat-label">Avg Query Count</div>
+                    <div class="stat-value">3.4</div>
+                </div>
+            </div>
+        </div>
+
+
+    <div class="card">
+        <h2>🐌 Slowest Tests (Top 10)</h2>
+        <ul class="test-list">
+
+        <li class="test-item pass">
+            <div class="test-name pass">SlideshowListCreateViewTestCase.test_list_users_see_public_published_and_own</div>
+            <div class="test-metrics">
+                <span><strong>84.55ms</strong></span>
+                <span>3 queries</span>
+
+            </div>
+        </li>
+
+        <li class="test-item pass">
+            <div class="test-name pass">UserListViewTest.test_list_users_performance_with_many_users</div>
+            <div class="test-metrics">
+                <span><strong>10.35ms</strong></span>
+                <span>3 queries</span>
+
+            </div>
+        </li>
+
+        <li class="test-item pass">
+            <div class="test-name pass">UserSearchViewTest.test_search_by_username</div>
+            <div class="test-metrics">
+                <span><strong>8.67ms</strong></span>
+                <span>4 queries</span>
+
+            </div>
+        </li>
+
+        <li class="test-item pass">
+            <div class="test-name pass">SlideshowRetrieveUpdateDestroyViewTestCase.test_update_increments_version</div>
+            <div class="test-metrics">
+                <span><strong>7.64ms</strong></span>
+                <span>8 queries</span>
+
+            </div>
+        </li>
+
+        <li class="test-item pass">
+            <div class="test-name pass">SlideshowRetrieveUpdateDestroyViewTestCase.test_detail_initial_param_limits_slides</div>
+            <div class="test-metrics">
+                <span><strong>6.20ms</strong></span>
+                <span>5 queries</span>
+
+            </div>
+        </li>
+
+        <li class="test-item pass">
+            <div class="test-name pass">PendingFriendRequestListViewTest.test_list_many_pending_requests_performance</div>
+            <div class="test-metrics">
+                <span><strong>6.11ms</strong></span>
+                <span>2 queries</span>
+
+            </div>
+        </li>
+
+        <li class="test-item pass">
+            <div class="test-name pass">UserListViewTest.test_list_users_authenticated</div>
+            <div class="test-metrics">
+                <span><strong>6.02ms</strong></span>
+                <span>3 queries</span>
+
+            </div>
+        </li>
+
+        <li class="test-item pass">
+            <div class="test-name pass">UserRetrieveViewTest.test_retrieve_user_authenticated_success</div>
+            <div class="test-metrics">
+                <span><strong>5.29ms</strong></span>
+                <span>2 queries</span>
+
+            </div>
+        </li>
+
+        <li class="test-item pass">
+            <div class="test-name pass">UserSearchViewTest.test_search_performance_with_many_users</div>
+            <div class="test-metrics">
+                <span><strong>5.05ms</strong></span>
+                <span>2 queries</span>
+
+            </div>
+        </li>
+
+        <li class="test-item pass">
+            <div class="test-name pass">PendingFriendRequestListViewTest.test_list_pending_requests_received</div>
+            <div class="test-metrics">
+                <span><strong>4.27ms</strong></span>
+                <span>2 queries</span>
+
+            </div>
+        </li>
+
+        </ul>
+    </div>
+
+
+
+        <div class="card">
+            <h2>🔄 N+1 Query Patterns</h2>
+            <div style="text-align: center; padding: 30px; color: #38a169;">
+                ✓ No N+1 patterns detected across all tests
+            </div>
+        </div>
+
+
+
+    <div class="card">
+        <h2>📋 All Test Results (15 tests)</h2>
+
+        <details>
+            <summary>
+                <span style="color: #38a169; font-weight: 700;">✓</span>
+                SlideshowListCreateViewTestCase.test_list_users_see_public_published_and_own -
+                <span style="color: #718096;">84.55ms, 3 queries</span>
+
+            </summary>
+            <div class="detail-content">
+
+            <div style="background: #f7fafc; padding: 12px; border-radius: 6px; margin-bottom: 12px;">
+                <strong>Metrics:</strong><br>
+                • Response time: 84.55ms (threshold: 100ms)<br>
+                • Query count: 3 (threshold: 5)<br>
+                • Location: <code style="font-size: 12px;">slideshows/tests/views/test_SlideshowListCreateView.py:64</code>
+            </div>
+
+            </div>
+        </details>
+
+        <details>
+            <summary>
+                <span style="color: #38a169; font-weight: 700;">✓</span>
+                SlideshowListCreateViewTestCase.test_create_success -
+                <span style="color: #718096;">4.14ms, 5 queries</span>
+
+            </summary>
+            <div class="detail-content">
+
+            <div style="background: #f7fafc; padding: 12px; border-radius: 6px; margin-bottom: 12px;">
+                <strong>Metrics:</strong><br>
+                • Response time: 4.14ms (threshold: 200ms)<br>
+                • Query count: 5 (threshold: 10)<br>
+                • Location: <code style="font-size: 12px;">slideshows/tests/views/test_SlideshowListCreateView.py:157</code>
+            </div>
+
+            </div>
+        </details>
+
+        <details>
+            <summary>
+                <span style="color: #38a169; font-weight: 700;">✓</span>
+                SlideshowRetrieveUpdateDestroyViewTestCase.test_detail_initial_param_limits_slides -
+                <span style="color: #718096;">6.20ms, 5 queries</span>
+
+            </summary>
+            <div class="detail-content">
+
+            <div style="background: #f7fafc; padding: 12px; border-radius: 6px; margin-bottom: 12px;">
+                <strong>Metrics:</strong><br>
+                • Response time: 6.20ms (threshold: 100ms)<br>
+                • Query count: 5 (threshold: 5)<br>
+                • Location: <code style="font-size: 12px;">slideshows/tests/views/test_SlideshowRetrieveUpdateDestroyView.py:52</code>
+            </div>
+
+            </div>
+        </details>
+
+        <details>
+            <summary>
+                <span style="color: #38a169; font-weight: 700;">✓</span>
+                SlideshowRetrieveUpdateDestroyViewTestCase.test_update_increments_version -
+                <span style="color: #718096;">7.64ms, 8 queries</span>
+
+            </summary>
+            <div class="detail-content">
+
+            <div style="background: #f7fafc; padding: 12px; border-radius: 6px; margin-bottom: 12px;">
+                <strong>Metrics:</strong><br>
+                • Response time: 7.64ms (threshold: 20ms)<br>
+                • Query count: 8 (threshold: 8)<br>
+                • Location: <code style="font-size: 12px;">slideshows/tests/views/test_SlideshowRetrieveUpdateDestroyView.py:94</code>
+            </div>
+
+            </div>
+        </details>
+
+        <details>
+            <summary>
+                <span style="color: #38a169; font-weight: 700;">✓</span>
+                GroupListCreateViewTest.test_list_groups_as_regular_user -
+                <span style="color: #718096;">3.26ms, 2 queries</span>
+
+            </summary>
+            <div class="detail-content">
+
+            <div style="background: #f7fafc; padding: 12px; border-radius: 6px; margin-bottom: 12px;">
+                <strong>Metrics:</strong><br>
+                • Response time: 3.26ms (threshold: 100ms)<br>
+                • Query count: 2 (threshold: 3)<br>
+                • Location: <code style="font-size: 12px;">users/tests/views/test_GroupListCreateView.py:48</code>
+            </div>
+
+            </div>
+        </details>
+
+        <details>
+            <summary>
+                <span style="color: #38a169; font-weight: 700;">✓</span>
+                UserRetrieveViewTest.test_retrieve_user_authenticated_success -
+                <span style="color: #718096;">5.29ms, 2 queries</span>
+
+            </summary>
+            <div class="detail-content">
+
+            <div style="background: #f7fafc; padding: 12px; border-radius: 6px; margin-bottom: 12px;">
+                <strong>Metrics:</strong><br>
+                • Response time: 5.29ms (threshold: 80ms)<br>
+                • Query count: 2 (threshold: 3)<br>
+                • Location: <code style="font-size: 12px;">users/tests/views/test_UserRetrieveView.py:36</code>
+            </div>
+
+            </div>
+        </details>
+
+        <details>
+            <summary>
+                <span style="color: #38a169; font-weight: 700;">✓</span>
+                UserSearchViewTest.test_search_by_username -
+                <span style="color: #718096;">8.67ms, 4 queries</span>
+
+            </summary>
+            <div class="detail-content">
+
+            <div style="background: #f7fafc; padding: 12px; border-radius: 6px; margin-bottom: 12px;">
+                <strong>Metrics:</strong><br>
+                • Response time: 8.67ms (threshold: 20ms)<br>
+                • Query count: 4 (threshold: 5)<br>
+                • Location: <code style="font-size: 12px;">users/tests/views/test_UserSearchView.py:103</code>
+            </div>
+
+            </div>
+        </details>
+
+        <details>
+            <summary>
+                <span style="color: #38a169; font-weight: 700;">✓</span>
+                UserSearchViewTest.test_search_performance_with_many_users -
+                <span style="color: #718096;">5.05ms, 2 queries</span>
+
+            </summary>
+            <div class="detail-content">
+
+            <div style="background: #f7fafc; padding: 12px; border-radius: 6px; margin-bottom: 12px;">
+                <strong>Metrics:</strong><br>
+                • Response time: 5.05ms (threshold: 2000ms)<br>
+                • Query count: 2 (threshold: 10)<br>
+                • Location: <code style="font-size: 12px;">users/tests/views/test_UserSearchView.py:381</code>
+            </div>
+
+            </div>
+        </details>
+
+        <details>
+            <summary>
+                <span style="color: #38a169; font-weight: 700;">✓</span>
+                UserProfileRetrieveUpdateViewTest.test_retrieve_own_profile_success -
+                <span style="color: #718096;">3.51ms, 3 queries</span>
+
+            </summary>
+            <div class="detail-content">
+
+            <div style="background: #f7fafc; padding: 12px; border-radius: 6px; margin-bottom: 12px;">
+                <strong>Metrics:</strong><br>
+                • Response time: 3.51ms (threshold: 100ms)<br>
+                • Query count: 3 (threshold: 4)<br>
+                • Location: <code style="font-size: 12px;">users/tests/views/test_UserProfileRetrieveUpdateView.py:44</code>
+            </div>
+
+            </div>
+        </details>
+
+        <details>
+            <summary>
+                <span style="color: #38a169; font-weight: 700;">✓</span>
+                UserProfilePrivacySettingsRetrieveUpdateViewTest.test_privacy_settings_update_performance -
+                <span style="color: #718096;">4.19ms, 3 queries</span>
+
+            </summary>
+            <div class="detail-content">
+
+            <div style="background: #f7fafc; padding: 12px; border-radius: 6px; margin-bottom: 12px;">
+                <strong>Metrics:</strong><br>
+                • Response time: 4.19ms (threshold: 100ms)<br>
+                • Query count: 3 (threshold: 3)<br>
+                • Location: <code style="font-size: 12px;">users/tests/views/test_UserProfilePrivacySettingsRetrieveUpdateView.py:381</code>
+            </div>
+
+            </div>
+        </details>
+
+        <details>
+            <summary>
+                <span style="color: #38a169; font-weight: 700;">✓</span>
+                UserListViewTest.test_list_users_authenticated -
+                <span style="color: #718096;">6.02ms, 3 queries</span>
+
+            </summary>
+            <div class="detail-content">
+
+            <div style="background: #f7fafc; padding: 12px; border-radius: 6px; margin-bottom: 12px;">
+                <strong>Metrics:</strong><br>
+                • Response time: 6.02ms (threshold: 100ms)<br>
+                • Query count: 3 (threshold: 5)<br>
+                • Location: <code style="font-size: 12px;">users/tests/views/test_UserListView.py:34</code>
+            </div>
+
+            </div>
+        </details>
+
+        <details>
+            <summary>
+                <span style="color: #38a169; font-weight: 700;">✓</span>
+                UserListViewTest.test_list_users_performance_with_many_users -
+                <span style="color: #718096;">10.35ms, 3 queries</span>
+
+            </summary>
+            <div class="detail-content">
+
+            <div style="background: #f7fafc; padding: 12px; border-radius: 6px; margin-bottom: 12px;">
+                <strong>Metrics:</strong><br>
+                • Response time: 10.35ms (threshold: 200ms)<br>
+                • Query count: 3 (threshold: 10)<br>
+                • Location: <code style="font-size: 12px;">users/tests/views/test_UserListView.py:234</code>
+            </div>
+
+            </div>
+        </details>
+
+        <details>
+            <summary>
+                <span style="color: #38a169; font-weight: 700;">✓</span>
+                PendingFriendRequestListViewTest.test_list_pending_requests_received -
+                <span style="color: #718096;">4.27ms, 2 queries</span>
+
+            </summary>
+            <div class="detail-content">
+
+            <div style="background: #f7fafc; padding: 12px; border-radius: 6px; margin-bottom: 12px;">
+                <strong>Metrics:</strong><br>
+                • Response time: 4.27ms (threshold: 100ms)<br>
+                • Query count: 2 (threshold: 5)<br>
+                • Location: <code style="font-size: 12px;">users/tests/views/test_PendingFriendRequestListView.py:57</code>
+            </div>
+
+            </div>
+        </details>
+
+        <details>
+            <summary>
+                <span style="color: #38a169; font-weight: 700;">✓</span>
+                PendingFriendRequestListViewTest.test_list_many_pending_requests_performance -
+                <span style="color: #718096;">6.11ms, 2 queries</span>
+
+            </summary>
+            <div class="detail-content">
+
+            <div style="background: #f7fafc; padding: 12px; border-radius: 6px; margin-bottom: 12px;">
+                <strong>Metrics:</strong><br>
+                • Response time: 6.11ms (threshold: 2000ms)<br>
+                • Query count: 2 (threshold: 10)<br>
+                • Location: <code style="font-size: 12px;">users/tests/views/test_PendingFriendRequestListView.py:212</code>
+            </div>
+
+            </div>
+        </details>
+
+        <details>
+            <summary>
+                <span style="color: #38a169; font-weight: 700;">✓</span>
+                CourseCreateAPITests.test_teacher_can_create_course -
+                <span style="color: #718096;">2.85ms, 4 queries</span>
+
+            </summary>
+            <div class="detail-content">
+
+            <div style="background: #f7fafc; padding: 12px; border-radius: 6px; margin-bottom: 12px;">
+                <strong>Metrics:</strong><br>
+                • Response time: 2.85ms (threshold: 150ms)<br>
+                • Query count: 4 (threshold: 6)<br>
+                • Location: <code style="font-size: 12px;">courses/tests/test_api_course_create.py:55</code>
+            </div>
+
+            </div>
+        </details>
+
+    </div>
+
+
+        <div class="footer">
+            Generated by <a href="https://github.com/yourusername/django-mercury-performance" target="_blank">Django Mercury Performance Testing</a> v0.1.1
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
# [FRONTEND] Slideshow Types & API Service

Closes #189

## Summary

Added TypeScript foundation for slideshow feature - complete type definitions and API service following existing patterns.

## Changes

### New Files
- `src/types/slideshow.types.ts` (172 lines)
  - Complete type definitions matching backend API
  - Slide types (owner vs non-owner views)
  - Request/response types with version conflict handling
  - Paginated response wrapper

- `src/services/slideshowApi.ts` (273 lines)
  - 9 API functions covering all endpoints
  - Progressive loading support (`?initial=N`)
  - Version conflict detection with helpers
  - Proper `AxiosError` typing for type safety

## API Coverage

✅ List slideshows with filters (mine, visibility, subject, language, country)  
✅ Get slideshow detail with progressive loading  
✅ Get individual slides for caching  
✅ Create slideshow with nested slides  
✅ Update slideshow with version conflict detection (409)  
✅ Delete slideshow  
✅ Helper functions for version conflicts  

## Type Safety

- All types match backend serializers exactly
- Used `AxiosError` instead of `any` for proper error handling
- Type guards for version conflict detection
- Proper TypeScript error handling with fallbacks

## Testing

- ✅ TypeScript compilation passes (`npx tsc --noEmit`)
- ✅ ESLint passes
- ✅ Follows existing `profileApi.ts` patterns

## Ready For

This foundation enables building:
- Slideshow viewer components
- Slideshow editor components  
- Progressive loading/caching logic
- Version conflict UI handling
