### PR TITLE
fix docker  `project_choices_data` causing test failures

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -38,8 +38,8 @@ WORKDIR /app
 # -------------------------------------------------------------------
 FROM base as dependencies
 
-# Copy requirements.txt from build context root (/backend/requirements.txt)
-COPY requirements.txt /requirements.txt
+# Copy requirements.txt from backend directory (build context is now repo root)
+COPY backend/requirements.txt /requirements.txt
 
 # Install Python dependencies
 RUN pip install --no-cache-dir -r /requirements.txt
@@ -49,8 +49,12 @@ RUN pip install --no-cache-dir -r /requirements.txt
 # -------------------------------------------------------------------
 FROM dependencies as runtime
 
-# Copy Django project from EduLite/ subdirectory
-COPY EduLite/ /app/
+# Copy Django project from backend/EduLite/ subdirectory
+COPY backend/EduLite/ /app/
+
+# Copy project choices data to container root for production deployments
+# (Development uses volume mount from docker-compose.yml)
+COPY project_choices_data/ /project_choices_data/
 
 # Note: entrypoint.sh will be bind-mounted via docker-compose.yml
 # This allows for easy editing without rebuilding the image

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -41,8 +41,8 @@ services:
   # Django Backend - REST API + WebSocket via Daphne ASGI
   backend:
     build:
-      context: ../backend
-      dockerfile: ../docker/backend/Dockerfile
+      context: ..
+      dockerfile: docker/backend/Dockerfile
     container_name: edulite-backend
     restart: unless-stopped
     environment:
@@ -73,6 +73,7 @@ services:
     volumes:
       - ../backend/EduLite:/app
       - ./backend/entrypoint.sh:/app/entrypoint.sh:ro
+      - ../project_choices_data:/project_choices_data:ro
       - media_data:/app/media
       - static_data:/app/staticfiles
       - logs_data:/app/logs


### PR DESCRIPTION
## Description

Fixes #194 - Backend Docker container cannot access `project_choices_data` causing test failures

This PR implements a **hybrid approach** to make the `project_choices_data` directory accessible to the backend Docker container, fixing 15 failing tests and enabling all choice-based model validation.

## Summary

- ✅ All 796 backend tests now pass (previously 15 failing)
- ✅ Model choices (countries, languages, occupations, subjects) properly loaded
- ✅ Profile updates and course creation work correctly
- ✅ Hybrid solution: volume mount for development + Dockerfile COPY for production

## Root Cause

The backend Django application expects to find `project_choices_data/` at the repository root (`/project_choices_data/` in the container), but:

1. The Dockerfile only copied the `EduLite/` directory
2. The build context was set to `../backend` instead of repository root
3. No volume mount was configured in docker-compose.yml

This caused `load_choices_from_json()` to return empty lists, breaking model validation for legitimate values like `"en"`, `"US"`, `"student"`.

## Changes Made

### 1. `docker/docker-compose.yml`

**Updated backend service configuration:**
```yaml
# Changed build context from ../backend to repository root
backend:
  build:
    context: ..  # Changed from: ../backend
    dockerfile: docker/backend/Dockerfile  # Changed from: ../docker/backend/Dockerfile
```

**Added volume mount for development:**
```yaml
volumes:
  - ../backend/EduLite:/app
  - ./backend/entrypoint.sh:/app/entrypoint.sh:ro
  - ../project_choices_data:/project_choices_data:ro  # ✨ NEW: Mount choices data
  - media_data:/app/media
  - static_data:/app/staticfiles
  - logs_data:/app/logs
```

### 2. `docker/backend/Dockerfile`

**Updated paths to account for new build context (repository root):**
```dockerfile
# Line 42: Updated requirements.txt path
COPY backend/requirements.txt /requirements.txt  # Changed from: COPY requirements.txt

# Line 53: Updated Django project path
COPY backend/EduLite/ /app/  # Changed from: COPY EduLite/

# Line 56-58: Added project_choices_data for production builds
COPY project_choices_data/ /project_choices_data/  # ✨ NEW
```

## Why Hybrid Approach?

### Development (Volume Mount)
- ✅ Edit JSON files without rebuilding containers
- ✅ Instant reflection of choice data changes
- ✅ Consistent with how other code is mounted
- ✅ Faster development iteration

### Production (Dockerfile COPY)
- ✅ Self-contained Docker image
- ✅ Works without external volume dependencies
- ✅ Reliable deployments
- ✅ Serves as fallback if volume mount fails

## Testing

### Before Fix
```
Ran 779 tests in 10.451s
FAILED (failures=8, errors=7)

ERROR: test_course_can_save_choices_fields
IndexError: list index out of range

FAIL: test_update_current_user_profile_success
ValidationError: {'preferred_language': ["Value 'en' is not a valid choice."]}
```

### After Fix
```
Ran 796 tests in 10.741s
OK

MERCURY SUMMARY
Total tests monitored: 15
Passed: 15 (100%)  Failed: 0 (0%)
```

## Deployment Notes

### For Development
No special action needed. Just rebuild and restart:
```bash
docker-compose build --no-cache backend
docker-compose up -d
```

### For Production
The Docker image now includes `project_choices_data/` directory, making it self-contained. No external volume mounts required.
