### PR TITLE
remove circular dependencies from userprofile model

### DIFF
--- a/backend/EduLite/users/models.py
+++ b/backend/EduLite/users/models.py
@@ -75,34 +75,6 @@ class UserProfile(models.Model):
             ret_str += f" {self.user.last_name}"
         return f"{ret_str}"
 
-    @property
-    def teachers(self):
-        """
-        Returns a queryset of Users who are teachers of this user in any course.
-        """
-        return (
-            self.courses.filter(memberships__role="teacher")
-            .distinct()
-            .values_list("memberships__user", flat=True)
-        )
-
-    @property
-    def chatrooms(self):
-        """
-        Returns a queryset of ChatRooms that this user is a member of.
-        """
-        from chat.models import ChatRoom
-
-        return ChatRoom.objects.filter(participants=self.user).values_list(
-            "id", flat=True
-        )
-
-    @property
-    def courses(self):
-        from courses.models import Course
-
-        return Course.objects.filter(memberships__user=self.user).distinct()
-
 
 class UserProfilePrivacySettings(models.Model):
     """

--- a/backend/EduLite/users/services/__init__.py
+++ b/backend/EduLite/users/services/__init__.py
@@ -1,3 +1,4 @@
 from .privacy_service import PrivacyService
+from .user_query_service import UserQueryService
 
-__all__ = ["PrivacyService"]
+__all__ = ["PrivacyService", "UserQueryService"]

--- a/backend/EduLite/users/services/user_query_service.py
+++ b/backend/EduLite/users/services/user_query_service.py
@@ -1,0 +1,134 @@
+"""
+User Query Service - Centralized cross-app query logic.
+
+Isolates queries that span multiple apps (users, courses, chat)
+to avoid circular dependencies in models.
+
+Usage:
+    from users.services import UserQueryService
+
+    # Get user's courses
+    courses = UserQueryService.get_user_courses(user)
+
+    # Get user's course IDs
+    course_ids = UserQueryService.get_user_course_ids(user)
+
+    # Get user's teachers
+    teacher_ids = UserQueryService.get_user_teacher_ids(user)
+
+    # Get user's chatroom IDs
+    chatroom_ids = UserQueryService.get_user_chatroom_ids(user)
+"""
+
+from typing import TYPE_CHECKING, Set
+
+from django.db.models import QuerySet
+
+if TYPE_CHECKING:
+    from django.contrib.auth.models import User
+
+
+class UserQueryService:
+    """
+    Centralized service for cross-app user queries.
+
+    Contains queries that would otherwise create circular dependencies
+    between the users app and other apps (courses, chat).
+
+    All methods are static since they don't require instance state.
+    """
+
+    # =========================================================================
+    # Course Queries
+    # =========================================================================
+
+    @staticmethod
+    def get_user_courses(user: "User") -> QuerySet:
+        """
+        Get all courses a user is a member of.
+
+        Args:
+            user: The user to get courses for
+
+        Returns:
+            QuerySet of Course objects
+        """
+        from courses.models import Course
+
+        return Course.objects.filter(memberships__user=user).distinct()
+
+    @staticmethod
+    def get_user_course_ids(user: "User") -> Set[int]:
+        """
+        Get IDs of all courses a user is a member of.
+
+        Args:
+            user: The user to get course IDs for
+
+        Returns:
+            Set of course IDs
+        """
+        return set(user.course_memberships.values_list("course_id", flat=True))
+
+    # =========================================================================
+    # Teacher Queries
+    # =========================================================================
+
+    @staticmethod
+    def get_user_teacher_ids(user: "User") -> Set[int]:
+        """
+        Get IDs of all teachers for courses the user is enrolled in.
+
+        This finds all users with the "teacher" role in any course
+        where the given user is a member.
+
+        Args:
+            user: The user to get teachers for
+
+        Returns:
+            Set of user IDs who are teachers of this user's courses
+        """
+        from courses.models import CourseMembership
+
+        course_ids = user.course_memberships.values_list("course_id", flat=True)
+        return set(
+            CourseMembership.objects.filter(
+                course_id__in=course_ids, role="teacher"
+            ).values_list("user_id", flat=True)
+        )
+
+    # =========================================================================
+    # Chatroom Queries
+    # =========================================================================
+
+    @staticmethod
+    def get_user_chatroom_ids(user: "User") -> Set[int]:
+        """
+        Get IDs of all chatrooms the user is a participant of.
+
+        Args:
+            user: The user to get chatroom IDs for
+
+        Returns:
+            Set of chatroom IDs
+        """
+        from chat.models import ChatRoom
+
+        return set(
+            ChatRoom.objects.filter(participants=user).values_list("id", flat=True)
+        )
+
+    @staticmethod
+    def get_user_chatrooms(user: "User") -> QuerySet:
+        """
+        Get all chatrooms the user is a participant of.
+
+        Args:
+            user: The user to get chatrooms for
+
+        Returns:
+            QuerySet of ChatRoom objects
+        """
+        from chat.models import ChatRoom
+
+        return ChatRoom.objects.filter(participants=user)

--- a/backend/EduLite/users/tests/services/test_user_query_service.py
+++ b/backend/EduLite/users/tests/services/test_user_query_service.py
@@ -1,0 +1,249 @@
+"""
+Tests for UserQueryService - centralized cross-app query logic.
+
+These tests verify that the UserQueryService correctly queries
+courses, teachers, and chatrooms without causing circular dependencies.
+"""
+
+from chat.models import ChatRoom
+from courses.models import Course, CourseMembership
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from users.services import UserQueryService
+
+
+class UserQueryServiceTestCase(TestCase):
+    """Base test case with common setup for user query service tests."""
+
+    def setUp(self):
+        """Set up test users, courses, and chatrooms."""
+        # Create test users
+        self.user1 = User.objects.create_user(
+            username="user1",
+            email="user1@example.com",
+        )
+        self.user2 = User.objects.create_user(
+            username="user2",
+            email="user2@example.com",
+        )
+        self.teacher1 = User.objects.create_user(
+            username="teacher1",
+            email="teacher1@example.com",
+        )
+        self.teacher2 = User.objects.create_user(
+            username="teacher2",
+            email="teacher2@example.com",
+        )
+
+
+class GetUserCoursesTests(UserQueryServiceTestCase):
+    """Tests for UserQueryService.get_user_courses()"""
+
+    def test_returns_enrolled_courses(self):
+        """User should see courses they are enrolled in."""
+        course = Course.objects.create(title="Test Course")
+        CourseMembership.objects.create(user=self.user1, course=course, role="student")
+
+        courses = UserQueryService.get_user_courses(self.user1)
+
+        self.assertEqual(courses.count(), 1)
+        self.assertIn(course, courses)
+
+    def test_returns_empty_when_not_enrolled(self):
+        """User with no memberships should get empty queryset."""
+        Course.objects.create(title="Test Course")
+
+        courses = UserQueryService.get_user_courses(self.user1)
+
+        self.assertEqual(courses.count(), 0)
+
+    def test_returns_multiple_courses(self):
+        """User enrolled in multiple courses should see all of them."""
+        course1 = Course.objects.create(title="Course 1")
+        course2 = Course.objects.create(title="Course 2")
+        CourseMembership.objects.create(user=self.user1, course=course1, role="student")
+        CourseMembership.objects.create(user=self.user1, course=course2, role="student")
+
+        courses = UserQueryService.get_user_courses(self.user1)
+
+        self.assertEqual(courses.count(), 2)
+        self.assertIn(course1, courses)
+        self.assertIn(course2, courses)
+
+    def test_returns_distinct_courses(self):
+        """User should not see duplicate courses if they have multiple roles."""
+        course = Course.objects.create(title="Test Course")
+        # User has two memberships in same course (shouldn't happen but test distinctness)
+        CourseMembership.objects.create(user=self.user1, course=course, role="student")
+
+        courses = UserQueryService.get_user_courses(self.user1)
+
+        self.assertEqual(courses.count(), 1)
+
+
+class GetUserCourseIdsTests(UserQueryServiceTestCase):
+    """Tests for UserQueryService.get_user_course_ids()"""
+
+    def test_returns_set_of_ids(self):
+        """Should return a set of course IDs."""
+        course1 = Course.objects.create(title="Course 1")
+        course2 = Course.objects.create(title="Course 2")
+        CourseMembership.objects.create(user=self.user1, course=course1, role="student")
+        CourseMembership.objects.create(user=self.user1, course=course2, role="student")
+
+        course_ids = UserQueryService.get_user_course_ids(self.user1)
+
+        self.assertIsInstance(course_ids, set)
+        self.assertEqual(course_ids, {course1.id, course2.id})
+
+    def test_returns_empty_set_when_not_enrolled(self):
+        """User with no memberships should get empty set."""
+        course_ids = UserQueryService.get_user_course_ids(self.user1)
+
+        self.assertEqual(course_ids, set())
+
+
+class GetUserTeacherIdsTests(UserQueryServiceTestCase):
+    """Tests for UserQueryService.get_user_teacher_ids()"""
+
+    def test_returns_teacher_ids_from_enrolled_courses(self):
+        """Should return teacher IDs from courses user is enrolled in."""
+        course = Course.objects.create(title="Test Course")
+        # Student enrolled in course
+        CourseMembership.objects.create(user=self.user1, course=course, role="student")
+        # Teacher in the same course
+        CourseMembership.objects.create(
+            user=self.teacher1, course=course, role="teacher"
+        )
+
+        teacher_ids = UserQueryService.get_user_teacher_ids(self.user1)
+
+        self.assertEqual(teacher_ids, {self.teacher1.id})
+
+    def test_excludes_teachers_from_other_courses(self):
+        """Should not include teachers from courses user is not enrolled in."""
+        course1 = Course.objects.create(title="Course 1")
+        course2 = Course.objects.create(title="Course 2")
+        # Student enrolled in course1 only
+        CourseMembership.objects.create(user=self.user1, course=course1, role="student")
+        # Teacher1 teaches course1
+        CourseMembership.objects.create(
+            user=self.teacher1, course=course1, role="teacher"
+        )
+        # Teacher2 teaches course2 (user not enrolled)
+        CourseMembership.objects.create(
+            user=self.teacher2, course=course2, role="teacher"
+        )
+
+        teacher_ids = UserQueryService.get_user_teacher_ids(self.user1)
+
+        self.assertEqual(teacher_ids, {self.teacher1.id})
+        self.assertNotIn(self.teacher2.id, teacher_ids)
+
+    def test_returns_empty_when_not_enrolled(self):
+        """User with no enrollments should get empty set."""
+        course = Course.objects.create(title="Test Course")
+        CourseMembership.objects.create(
+            user=self.teacher1, course=course, role="teacher"
+        )
+
+        teacher_ids = UserQueryService.get_user_teacher_ids(self.user1)
+
+        self.assertEqual(teacher_ids, set())
+
+    def test_returns_multiple_teachers(self):
+        """Should return all teachers from user's courses."""
+        course = Course.objects.create(title="Test Course")
+        CourseMembership.objects.create(user=self.user1, course=course, role="student")
+        CourseMembership.objects.create(
+            user=self.teacher1, course=course, role="teacher"
+        )
+        CourseMembership.objects.create(
+            user=self.teacher2, course=course, role="teacher"
+        )
+
+        teacher_ids = UserQueryService.get_user_teacher_ids(self.user1)
+
+        self.assertEqual(teacher_ids, {self.teacher1.id, self.teacher2.id})
+
+    def test_excludes_non_teacher_roles(self):
+        """Should only include users with 'teacher' role."""
+        course = Course.objects.create(title="Test Course")
+        CourseMembership.objects.create(user=self.user1, course=course, role="student")
+        CourseMembership.objects.create(user=self.user2, course=course, role="student")
+        CourseMembership.objects.create(
+            user=self.teacher1, course=course, role="teacher"
+        )
+
+        teacher_ids = UserQueryService.get_user_teacher_ids(self.user1)
+
+        self.assertEqual(teacher_ids, {self.teacher1.id})
+        self.assertNotIn(self.user2.id, teacher_ids)
+
+
+class GetUserChatroomIdsTests(UserQueryServiceTestCase):
+    """Tests for UserQueryService.get_user_chatroom_ids()"""
+
+    def test_returns_participated_chatroom_ids(self):
+        """Should return IDs of chatrooms user participates in."""
+        chatroom = ChatRoom.objects.create(room_type="GROUP")
+        chatroom.participants.add(self.user1)
+
+        chatroom_ids = UserQueryService.get_user_chatroom_ids(self.user1)
+
+        self.assertEqual(chatroom_ids, {chatroom.id})
+
+    def test_returns_empty_when_no_participation(self):
+        """User with no chatroom participation should get empty set."""
+        ChatRoom.objects.create(room_type="GROUP")
+
+        chatroom_ids = UserQueryService.get_user_chatroom_ids(self.user1)
+
+        self.assertEqual(chatroom_ids, set())
+
+    def test_returns_multiple_chatroom_ids(self):
+        """Should return all chatroom IDs user participates in."""
+        chatroom1 = ChatRoom.objects.create(room_type="GROUP")
+        chatroom2 = ChatRoom.objects.create(room_type="ONE_TO_ONE")
+        chatroom1.participants.add(self.user1)
+        chatroom2.participants.add(self.user1)
+
+        chatroom_ids = UserQueryService.get_user_chatroom_ids(self.user1)
+
+        self.assertEqual(chatroom_ids, {chatroom1.id, chatroom2.id})
+
+    def test_excludes_non_participated_chatrooms(self):
+        """Should not include chatrooms user doesn't participate in."""
+        chatroom1 = ChatRoom.objects.create(room_type="GROUP")
+        chatroom2 = ChatRoom.objects.create(room_type="GROUP")
+        chatroom1.participants.add(self.user1)
+        chatroom2.participants.add(self.user2)  # user1 not added
+
+        chatroom_ids = UserQueryService.get_user_chatroom_ids(self.user1)
+
+        self.assertEqual(chatroom_ids, {chatroom1.id})
+        self.assertNotIn(chatroom2.id, chatroom_ids)
+
+
+class GetUserChatroomsTests(UserQueryServiceTestCase):
+    """Tests for UserQueryService.get_user_chatrooms()"""
+
+    def test_returns_queryset_of_chatrooms(self):
+        """Should return a QuerySet of ChatRoom objects."""
+        chatroom1 = ChatRoom.objects.create(room_type="GROUP")
+        chatroom2 = ChatRoom.objects.create(room_type="ONE_TO_ONE")
+        chatroom1.participants.add(self.user1)
+        chatroom2.participants.add(self.user1)
+
+        chatrooms = UserQueryService.get_user_chatrooms(self.user1)
+
+        self.assertEqual(chatrooms.count(), 2)
+        self.assertIn(chatroom1, chatrooms)
+        self.assertIn(chatroom2, chatrooms)
+
+    def test_returns_empty_queryset_when_no_participation(self):
+        """User with no chatroom participation should get empty queryset."""
+        chatrooms = UserQueryService.get_user_chatrooms(self.user1)
+
+        self.assertEqual(chatrooms.count(), 0)


### PR DESCRIPTION
## Summary

Removes circular dependencies from `UserProfile` model by extracting cross-app queries into a dedicated `UserQueryService`.

Closes #203

## Changes

### New Files
- `users/services/user_query_service.py` - Service for cross-app queries (courses, teachers, chatrooms)
- `users/tests/services/test_user_query_service.py` - 17 tests for the service

### Modified Files
- `users/services/__init__.py` - Exports new UserQueryService
- `users/models.py` - Removed `courses`, `chatrooms`, `teachers` properties
- `users/logic/friend_suggestions.py` - Uses UserQueryService instead of profile properties

## Why

The `UserProfile` model had dynamic imports inside property methods to avoid circular dependencies:

```python
@property
def courses(self):
    from courses.models import Course  # Code smell
    return Course.objects.filter(memberships__user=self.user)
```

This pattern:
- Makes the dependency graph confusing
- Hides cross-app coupling inside models
- Is harder to test and maintain

Now cross-app queries are isolated in `UserQueryService`, keeping models clean.

## Backwards Compatible

The removed properties were only used in `friend_suggestions.py`, which has been updated.

## Tests

- All 645 existing users app tests pass
- 17 new tests added for UserQueryService
- mypy passes with no errors
