### PR TITLE
refactor slideshowviewer for custom hooks

### DIFF
--- a/Frontend/EduLiteFrontend/_temp/pr-description.md
+++ b/Frontend/EduLiteFrontend/_temp/pr-description.md
@@ -1,0 +1,93 @@
+# Refactor: Decompose SlideshowViewer into Custom Hooks
+
+Closes #202
+
+## Summary
+
+Refactored the `SlideshowViewer` component from 643 lines with 13+ intertwined useState hooks into a cleaner architecture using 4 focused custom hooks. The component is now 450 lines (30% reduction) with clear separation of concerns.
+
+## Changes
+
+### New Hooks Created
+
+| Hook | Lines | Purpose |
+|------|-------|---------|
+| `useSlideNavigation` | 80 | Manages slide index, next/prev/goToSlide with bounds checking |
+| `useSlideLoader` | 168 | Handles API calls, progressive loading, metadata |
+| `usePresentationMode` | 178 | Fullscreen API, auto-hide bars, localStorage persistence |
+| `useKeyboardNavigation` | 138 | Keyboard shortcuts (arrows, space, N, F, Home/End, 1-9) |
+
+### New Test Files
+
+| Test File | Tests | Coverage |
+|-----------|-------|----------|
+| `useSlideNavigation.test.ts` | 20 | Initialization, navigation, bounds, edge cases |
+| `useSlideLoader.test.ts` | 16 | Loading states, errors, progressive loading |
+| `usePresentationMode.test.ts` | 21 | Fullscreen, auto-hide, localStorage, mouse tracking |
+| `useKeyboardNavigation.test.ts` | 21 | All keyboard shortcuts, enabled/disabled states |
+
+### Modified Files
+
+- `SlideshowViewer.tsx` - Now uses the 4 custom hooks instead of inline state management
+
+## Before/After
+
+**Before:**
+```tsx
+// 643 lines, 13+ useState hooks
+const [currentIndex, setCurrentIndex] = useState(initialSlide);
+const [slides, setSlides] = useState(new Map());
+const [showNotes, setShowNotes] = useState(showNotesInitial);
+const [isLoading, setIsLoading] = useState(true);
+const [error, setError] = useState(null);
+const [isFullscreen, setIsFullscreen] = useState(false);
+// ... 7 more state variables
+```
+
+**After:**
+```tsx
+// 450 lines, clean separation of concerns
+const { slides, slideCount, isLoading, error, metadata } = useSlideLoader(slideshowId);
+const navigation = useSlideNavigation({ slideCount, initialSlide });
+const presentation = usePresentationMode({ containerRef, showNotes, settingsOpen, helpOpen });
+
+useKeyboardNavigation({
+  onNext: navigation.next,
+  onPrev: navigation.prev,
+  onGoToSlide: navigation.goToSlide,
+  onToggleNotes: toggleNotes,
+  onToggleFullscreen: handleToggleFullscreen,
+  onExit,
+  slideCount,
+  allowFullscreen,
+});
+```
+
+## Benefits
+
+1. **Clarity** - Each hook does one thing, easy to understand in isolation
+2. **Testability** - Can unit test navigation logic without rendering the full component
+3. **Reusability** - `useSlideNavigation` could be reused for carousels, image galleries, etc.
+4. **Maintainability** - Bug in fullscreen? Look at `usePresentationMode`, not 600+ lines
+
+## Testing
+
+- All 488 existing tests pass
+- 78 new unit tests for the custom hooks
+- TypeScript compiles without errors
+- Original `SlideshowViewer.test.tsx` unchanged and passing (proves external API preserved)
+
+## Files Changed
+
+**Created:**
+- `src/hooks/useSlideNavigation.ts`
+- `src/hooks/useSlideLoader.ts`
+- `src/hooks/usePresentationMode.ts`
+- `src/hooks/useKeyboardNavigation.ts`
+- `src/hooks/__tests__/useSlideNavigation.test.ts`
+- `src/hooks/__tests__/useSlideLoader.test.ts`
+- `src/hooks/__tests__/usePresentationMode.test.ts`
+- `src/hooks/__tests__/useKeyboardNavigation.test.ts`
+
+**Modified:**
+- `src/components/slideshow/SlideshowViewer.tsx`

--- a/Frontend/EduLiteFrontend/src/hooks/__tests__/useKeyboardNavigation.test.ts
+++ b/Frontend/EduLiteFrontend/src/hooks/__tests__/useKeyboardNavigation.test.ts
@@ -1,0 +1,370 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useKeyboardNavigation } from "../useKeyboardNavigation";
+
+describe("useKeyboardNavigation", () => {
+  const mockCallbacks = {
+    onNext: vi.fn(),
+    onPrev: vi.fn(),
+    onGoToSlide: vi.fn(),
+    onToggleNotes: vi.fn(),
+    onToggleFullscreen: vi.fn(),
+    onExit: vi.fn(),
+  };
+
+  const fireKeyDown = (key: string) => {
+    const event = new KeyboardEvent("keydown", { key, bubbles: true });
+    vi.spyOn(event, "preventDefault");
+    window.dispatchEvent(event);
+    return event;
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("next slide navigation", () => {
+    it("should call onNext when ArrowRight is pressed", () => {
+      renderHook(() =>
+        useKeyboardNavigation({
+          ...mockCallbacks,
+          slideCount: 10,
+        })
+      );
+
+      const event = fireKeyDown("ArrowRight");
+
+      expect(mockCallbacks.onNext).toHaveBeenCalledTimes(1);
+      expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    it("should call onNext when Space is pressed", () => {
+      renderHook(() =>
+        useKeyboardNavigation({
+          ...mockCallbacks,
+          slideCount: 10,
+        })
+      );
+
+      const event = fireKeyDown(" ");
+
+      expect(mockCallbacks.onNext).toHaveBeenCalledTimes(1);
+      expect(event.preventDefault).toHaveBeenCalled();
+    });
+  });
+
+  describe("previous slide navigation", () => {
+    it("should call onPrev when ArrowLeft is pressed", () => {
+      renderHook(() =>
+        useKeyboardNavigation({
+          ...mockCallbacks,
+          slideCount: 10,
+        })
+      );
+
+      const event = fireKeyDown("ArrowLeft");
+
+      expect(mockCallbacks.onPrev).toHaveBeenCalledTimes(1);
+      expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    it("should call onPrev when Backspace is pressed", () => {
+      renderHook(() =>
+        useKeyboardNavigation({
+          ...mockCallbacks,
+          slideCount: 10,
+        })
+      );
+
+      const event = fireKeyDown("Backspace");
+
+      expect(mockCallbacks.onPrev).toHaveBeenCalledTimes(1);
+      expect(event.preventDefault).toHaveBeenCalled();
+    });
+  });
+
+  describe("speaker notes toggle", () => {
+    it("should call onToggleNotes when n is pressed", () => {
+      renderHook(() =>
+        useKeyboardNavigation({
+          ...mockCallbacks,
+          slideCount: 10,
+        })
+      );
+
+      const event = fireKeyDown("n");
+
+      expect(mockCallbacks.onToggleNotes).toHaveBeenCalledTimes(1);
+      expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    it("should call onToggleNotes when N is pressed", () => {
+      renderHook(() =>
+        useKeyboardNavigation({
+          ...mockCallbacks,
+          slideCount: 10,
+        })
+      );
+
+      const event = fireKeyDown("N");
+
+      expect(mockCallbacks.onToggleNotes).toHaveBeenCalledTimes(1);
+      expect(event.preventDefault).toHaveBeenCalled();
+    });
+  });
+
+  describe("first/last slide navigation", () => {
+    it("should call onGoToSlide(0) when Home is pressed", () => {
+      renderHook(() =>
+        useKeyboardNavigation({
+          ...mockCallbacks,
+          slideCount: 10,
+        })
+      );
+
+      const event = fireKeyDown("Home");
+
+      expect(mockCallbacks.onGoToSlide).toHaveBeenCalledWith(0);
+      expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    it("should call onGoToSlide(slideCount - 1) when End is pressed", () => {
+      renderHook(() =>
+        useKeyboardNavigation({
+          ...mockCallbacks,
+          slideCount: 10,
+        })
+      );
+
+      const event = fireKeyDown("End");
+
+      expect(mockCallbacks.onGoToSlide).toHaveBeenCalledWith(9);
+      expect(event.preventDefault).toHaveBeenCalled();
+    });
+  });
+
+  describe("number key navigation", () => {
+    it("should navigate to slide 0 when 1 is pressed", () => {
+      renderHook(() =>
+        useKeyboardNavigation({
+          ...mockCallbacks,
+          slideCount: 10,
+        })
+      );
+
+      const event = fireKeyDown("1");
+
+      expect(mockCallbacks.onGoToSlide).toHaveBeenCalledWith(0);
+      expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    it("should navigate to slide 4 when 5 is pressed", () => {
+      renderHook(() =>
+        useKeyboardNavigation({
+          ...mockCallbacks,
+          slideCount: 10,
+        })
+      );
+
+      const event = fireKeyDown("5");
+
+      expect(mockCallbacks.onGoToSlide).toHaveBeenCalledWith(4);
+      expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    it("should navigate to slide 8 when 9 is pressed", () => {
+      renderHook(() =>
+        useKeyboardNavigation({
+          ...mockCallbacks,
+          slideCount: 10,
+        })
+      );
+
+      const event = fireKeyDown("9");
+
+      expect(mockCallbacks.onGoToSlide).toHaveBeenCalledWith(8);
+      expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    it("should not navigate when number exceeds slideCount", () => {
+      renderHook(() =>
+        useKeyboardNavigation({
+          ...mockCallbacks,
+          slideCount: 3,
+        })
+      );
+
+      fireKeyDown("5");
+
+      expect(mockCallbacks.onGoToSlide).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("fullscreen toggle", () => {
+    it("should call onToggleFullscreen when f is pressed and allowed", () => {
+      renderHook(() =>
+        useKeyboardNavigation({
+          ...mockCallbacks,
+          slideCount: 10,
+          allowFullscreen: true,
+        })
+      );
+
+      const event = fireKeyDown("f");
+
+      expect(mockCallbacks.onToggleFullscreen).toHaveBeenCalledTimes(1);
+      expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    it("should call onToggleFullscreen when F is pressed and allowed", () => {
+      renderHook(() =>
+        useKeyboardNavigation({
+          ...mockCallbacks,
+          slideCount: 10,
+          allowFullscreen: true,
+        })
+      );
+
+      const event = fireKeyDown("F");
+
+      expect(mockCallbacks.onToggleFullscreen).toHaveBeenCalledTimes(1);
+      expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    it("should not call onToggleFullscreen when allowFullscreen is false", () => {
+      renderHook(() =>
+        useKeyboardNavigation({
+          ...mockCallbacks,
+          slideCount: 10,
+          allowFullscreen: false,
+        })
+      );
+
+      fireKeyDown("f");
+
+      expect(mockCallbacks.onToggleFullscreen).not.toHaveBeenCalled();
+    });
+
+    it("should not call onToggleFullscreen when not provided", () => {
+      renderHook(() =>
+        useKeyboardNavigation({
+          onNext: mockCallbacks.onNext,
+          onPrev: mockCallbacks.onPrev,
+          onGoToSlide: mockCallbacks.onGoToSlide,
+          onToggleNotes: mockCallbacks.onToggleNotes,
+          slideCount: 10,
+          allowFullscreen: true,
+        })
+      );
+
+      fireKeyDown("f");
+
+      // Should not throw, just silently do nothing
+      expect(mockCallbacks.onToggleFullscreen).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("escape key", () => {
+    it("should call onExit when Escape is pressed and not in fullscreen", () => {
+      renderHook(() =>
+        useKeyboardNavigation({
+          ...mockCallbacks,
+          slideCount: 10,
+        })
+      );
+
+      const event = fireKeyDown("Escape");
+
+      expect(mockCallbacks.onExit).toHaveBeenCalledTimes(1);
+      expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    it("should exit fullscreen when Escape is pressed in fullscreen mode", () => {
+      // Mock fullscreen state
+      const exitFullscreenMock = vi.fn();
+      Object.defineProperty(document, "fullscreenElement", {
+        value: document.createElement("div"),
+        configurable: true,
+      });
+      document.exitFullscreen = exitFullscreenMock;
+
+      renderHook(() =>
+        useKeyboardNavigation({
+          ...mockCallbacks,
+          slideCount: 10,
+        })
+      );
+
+      fireKeyDown("Escape");
+
+      expect(exitFullscreenMock).toHaveBeenCalled();
+      expect(mockCallbacks.onExit).not.toHaveBeenCalled();
+
+      // Restore
+      Object.defineProperty(document, "fullscreenElement", {
+        value: null,
+        configurable: true,
+      });
+    });
+  });
+
+  describe("enabled flag", () => {
+    it("should not respond to keys when disabled", () => {
+      renderHook(() =>
+        useKeyboardNavigation({
+          ...mockCallbacks,
+          slideCount: 10,
+          enabled: false,
+        })
+      );
+
+      fireKeyDown("ArrowRight");
+      fireKeyDown("ArrowLeft");
+      fireKeyDown("n");
+
+      expect(mockCallbacks.onNext).not.toHaveBeenCalled();
+      expect(mockCallbacks.onPrev).not.toHaveBeenCalled();
+      expect(mockCallbacks.onToggleNotes).not.toHaveBeenCalled();
+    });
+
+    it("should respond to keys when enabled", () => {
+      renderHook(() =>
+        useKeyboardNavigation({
+          ...mockCallbacks,
+          slideCount: 10,
+          enabled: true,
+        })
+      );
+
+      fireKeyDown("ArrowRight");
+
+      expect(mockCallbacks.onNext).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("cleanup", () => {
+    it("should remove event listener on unmount", () => {
+      const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
+
+      const { unmount } = renderHook(() =>
+        useKeyboardNavigation({
+          ...mockCallbacks,
+          slideCount: 10,
+        })
+      );
+
+      unmount();
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith(
+        "keydown",
+        expect.any(Function)
+      );
+
+      removeEventListenerSpy.mockRestore();
+    });
+  });
+});

--- a/Frontend/EduLiteFrontend/src/hooks/__tests__/usePresentationMode.test.ts
+++ b/Frontend/EduLiteFrontend/src/hooks/__tests__/usePresentationMode.test.ts
@@ -1,0 +1,373 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { usePresentationMode } from "../usePresentationMode";
+
+describe("usePresentationMode", () => {
+  let mockContainerRef: { current: HTMLDivElement | null };
+
+  beforeEach(() => {
+    // Create a mock container element
+    mockContainerRef = { current: document.createElement("div") };
+
+    // Clear localStorage
+    localStorage.clear();
+
+    // Reset fullscreen state
+    Object.defineProperty(document, "fullscreenElement", {
+      value: null,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  describe("auto-hide settings initialization", () => {
+    it("should default to auto-hide enabled for both bars", () => {
+      const { result } = renderHook(() =>
+        usePresentationMode({ containerRef: mockContainerRef })
+      );
+
+      expect(result.current.autoHideTopBar).toBe(true);
+      expect(result.current.autoHideBottomBar).toBe(true);
+    });
+
+    it("should load saved settings from localStorage", () => {
+      localStorage.setItem("slideshow-auto-hide-top", "false");
+      localStorage.setItem("slideshow-auto-hide-bottom", "false");
+
+      const { result } = renderHook(() =>
+        usePresentationMode({ containerRef: mockContainerRef })
+      );
+
+      expect(result.current.autoHideTopBar).toBe(false);
+      expect(result.current.autoHideBottomBar).toBe(false);
+    });
+
+    it("should handle corrupted localStorage gracefully", () => {
+      localStorage.setItem("slideshow-auto-hide-top", "not-valid-json{");
+
+      const { result } = renderHook(() =>
+        usePresentationMode({ containerRef: mockContainerRef })
+      );
+
+      // Should fall back to default
+      expect(result.current.autoHideTopBar).toBe(true);
+    });
+  });
+
+  describe("setAutoHideTopBar", () => {
+    it("should update state and persist to localStorage", () => {
+      const { result } = renderHook(() =>
+        usePresentationMode({ containerRef: mockContainerRef })
+      );
+
+      act(() => {
+        result.current.setAutoHideTopBar(false);
+      });
+
+      expect(result.current.autoHideTopBar).toBe(false);
+      expect(localStorage.getItem("slideshow-auto-hide-top")).toBe("false");
+    });
+  });
+
+  describe("setAutoHideBottomBar", () => {
+    it("should update state and persist to localStorage", () => {
+      const { result } = renderHook(() =>
+        usePresentationMode({ containerRef: mockContainerRef })
+      );
+
+      act(() => {
+        result.current.setAutoHideBottomBar(false);
+      });
+
+      expect(result.current.autoHideBottomBar).toBe(false);
+      expect(localStorage.getItem("slideshow-auto-hide-bottom")).toBe("false");
+    });
+  });
+
+  describe("shouldShowTopBar", () => {
+    it("should always show when autoHideTopBar is false", () => {
+      const { result } = renderHook(() =>
+        usePresentationMode({ containerRef: mockContainerRef })
+      );
+
+      act(() => {
+        result.current.setAutoHideTopBar(false);
+      });
+
+      expect(result.current.shouldShowTopBar).toBe(true);
+    });
+
+    it("should show when settingsOpen is true", () => {
+      const { result } = renderHook(() =>
+        usePresentationMode({
+          containerRef: mockContainerRef,
+          settingsOpen: true,
+        })
+      );
+
+      expect(result.current.shouldShowTopBar).toBe(true);
+    });
+
+    it("should show when helpOpen is true", () => {
+      const { result } = renderHook(() =>
+        usePresentationMode({
+          containerRef: mockContainerRef,
+          helpOpen: true,
+        })
+      );
+
+      expect(result.current.shouldShowTopBar).toBe(true);
+    });
+  });
+
+  describe("shouldShowBottomBar", () => {
+    it("should always show when autoHideBottomBar is false", () => {
+      const { result } = renderHook(() =>
+        usePresentationMode({ containerRef: mockContainerRef })
+      );
+
+      act(() => {
+        result.current.setAutoHideBottomBar(false);
+      });
+
+      expect(result.current.shouldShowBottomBar).toBe(true);
+    });
+  });
+
+  describe("mouse hover tracking", () => {
+    it("should show top bar when mouse is near top edge", () => {
+      const { result } = renderHook(() =>
+        usePresentationMode({ containerRef: mockContainerRef })
+      );
+
+      // Simulate mouse move near top
+      act(() => {
+        const event = new MouseEvent("mousemove", {
+          clientY: 50, // Within 100px threshold
+          bubbles: true,
+        });
+        window.dispatchEvent(event);
+      });
+
+      expect(result.current.shouldShowTopBar).toBe(true);
+    });
+
+    it("should hide top bar when mouse is away from top edge", () => {
+      const { result } = renderHook(() =>
+        usePresentationMode({ containerRef: mockContainerRef })
+      );
+
+      // Simulate mouse move away from top
+      act(() => {
+        const event = new MouseEvent("mousemove", {
+          clientY: 500, // Beyond 100px threshold
+          bubbles: true,
+        });
+        window.dispatchEvent(event);
+      });
+
+      expect(result.current.shouldShowTopBar).toBe(false);
+    });
+
+    it("should show bottom bar when mouse is near bottom edge", () => {
+      // Mock window.innerHeight
+      Object.defineProperty(window, "innerHeight", {
+        value: 800,
+        configurable: true,
+      });
+
+      const { result } = renderHook(() =>
+        usePresentationMode({ containerRef: mockContainerRef })
+      );
+
+      // Simulate mouse move near bottom
+      act(() => {
+        const event = new MouseEvent("mousemove", {
+          clientY: 750, // Within 100px of bottom (800 - 100 = 700)
+          bubbles: true,
+        });
+        window.dispatchEvent(event);
+      });
+
+      expect(result.current.shouldShowBottomBar).toBe(true);
+    });
+
+    it("should use larger threshold when notes are open", () => {
+      Object.defineProperty(window, "innerHeight", {
+        value: 800,
+        configurable: true,
+      });
+
+      const { result } = renderHook(() =>
+        usePresentationMode({
+          containerRef: mockContainerRef,
+          showNotes: true,
+        })
+      );
+
+      // Simulate mouse move that's beyond 100px but within 450px threshold
+      act(() => {
+        const event = new MouseEvent("mousemove", {
+          clientY: 400, // Beyond normal threshold, but within notes threshold (800 - 450 = 350)
+          bubbles: true,
+        });
+        window.dispatchEvent(event);
+      });
+
+      expect(result.current.shouldShowBottomBar).toBe(true);
+    });
+  });
+
+  describe("fullscreen", () => {
+    it("should start not in fullscreen", () => {
+      const { result } = renderHook(() =>
+        usePresentationMode({ containerRef: mockContainerRef })
+      );
+
+      expect(result.current.isFullscreen).toBe(false);
+    });
+
+    it("should toggle fullscreen on", async () => {
+      const requestFullscreenMock = vi.fn().mockResolvedValue(undefined);
+      mockContainerRef.current!.requestFullscreen = requestFullscreenMock;
+
+      const { result } = renderHook(() =>
+        usePresentationMode({ containerRef: mockContainerRef })
+      );
+
+      await act(async () => {
+        await result.current.toggleFullscreen();
+      });
+
+      expect(requestFullscreenMock).toHaveBeenCalled();
+      expect(result.current.isFullscreen).toBe(true);
+    });
+
+    it("should toggle fullscreen off", async () => {
+      // Start in fullscreen
+      Object.defineProperty(document, "fullscreenElement", {
+        value: mockContainerRef.current,
+        configurable: true,
+      });
+
+      const exitFullscreenMock = vi.fn().mockResolvedValue(undefined);
+      document.exitFullscreen = exitFullscreenMock;
+
+      const { result } = renderHook(() =>
+        usePresentationMode({ containerRef: mockContainerRef })
+      );
+
+      await act(async () => {
+        await result.current.toggleFullscreen();
+      });
+
+      expect(exitFullscreenMock).toHaveBeenCalled();
+      expect(result.current.isFullscreen).toBe(false);
+    });
+
+    it("should handle fullscreen errors", async () => {
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const requestFullscreenMock = vi.fn().mockRejectedValue(new Error("Fullscreen denied"));
+      mockContainerRef.current!.requestFullscreen = requestFullscreenMock;
+
+      const { result } = renderHook(() =>
+        usePresentationMode({ containerRef: mockContainerRef })
+      );
+
+      await expect(
+        act(async () => {
+          await result.current.toggleFullscreen();
+        })
+      ).rejects.toThrow("Fullscreen denied");
+
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      consoleErrorSpy.mockRestore();
+    });
+
+    it("should do nothing when containerRef is null", async () => {
+      const nullRef = { current: null };
+
+      const { result } = renderHook(() =>
+        usePresentationMode({ containerRef: nullRef })
+      );
+
+      // Should not throw
+      await act(async () => {
+        await result.current.toggleFullscreen();
+      });
+
+      expect(result.current.isFullscreen).toBe(false);
+    });
+
+    it("should update isFullscreen on fullscreenchange event", () => {
+      const { result } = renderHook(() =>
+        usePresentationMode({ containerRef: mockContainerRef })
+      );
+
+      expect(result.current.isFullscreen).toBe(false);
+
+      // Simulate entering fullscreen
+      act(() => {
+        Object.defineProperty(document, "fullscreenElement", {
+          value: mockContainerRef.current,
+          configurable: true,
+        });
+        document.dispatchEvent(new Event("fullscreenchange"));
+      });
+
+      expect(result.current.isFullscreen).toBe(true);
+
+      // Simulate exiting fullscreen
+      act(() => {
+        Object.defineProperty(document, "fullscreenElement", {
+          value: null,
+          configurable: true,
+        });
+        document.dispatchEvent(new Event("fullscreenchange"));
+      });
+
+      expect(result.current.isFullscreen).toBe(false);
+    });
+  });
+
+  describe("cleanup", () => {
+    it("should remove mousemove listener on unmount", () => {
+      const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
+
+      const { unmount } = renderHook(() =>
+        usePresentationMode({ containerRef: mockContainerRef })
+      );
+
+      unmount();
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith(
+        "mousemove",
+        expect.any(Function)
+      );
+
+      removeEventListenerSpy.mockRestore();
+    });
+
+    it("should remove fullscreenchange listener on unmount", () => {
+      const removeEventListenerSpy = vi.spyOn(document, "removeEventListener");
+
+      const { unmount } = renderHook(() =>
+        usePresentationMode({ containerRef: mockContainerRef })
+      );
+
+      unmount();
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith(
+        "fullscreenchange",
+        expect.any(Function)
+      );
+
+      removeEventListenerSpy.mockRestore();
+    });
+  });
+});

--- a/Frontend/EduLiteFrontend/src/hooks/__tests__/useSlideLoader.test.ts
+++ b/Frontend/EduLiteFrontend/src/hooks/__tests__/useSlideLoader.test.ts
@@ -1,0 +1,418 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useSlideLoader } from "../useSlideLoader";
+import * as slideshowApi from "../../services/slideshowApi";
+import type { SlideshowDetail, Slide } from "../../types/slideshow.types";
+
+// Mock the slideshowApi
+vi.mock("../../services/slideshowApi");
+
+// Mock react-hot-toast
+vi.mock("react-hot-toast", () => ({
+  default: {
+    error: vi.fn(),
+  },
+}));
+
+describe("useSlideLoader", () => {
+  const mockSlideshowDetail: SlideshowDetail = {
+    id: 1,
+    title: "Test Slideshow",
+    description: "Test description",
+    created_by: 1,
+    created_by_username: "testuser",
+    visibility: "public",
+    language: "en",
+    country: "US",
+    subject: "cs",
+    is_published: true,
+    version: 1,
+    slide_count: 5,
+    slides: [
+      {
+        id: 1,
+        order: 0,
+        content: "# Slide 1",
+        rendered_content: "<h1>Slide 1</h1>",
+        notes: "Notes 1",
+        created_at: "2024-01-01T00:00:00Z",
+        updated_at: "2024-01-01T00:00:00Z",
+      },
+      {
+        id: 2,
+        order: 1,
+        content: "# Slide 2",
+        rendered_content: "<h1>Slide 2</h1>",
+        notes: null,
+        created_at: "2024-01-01T00:00:00Z",
+        updated_at: "2024-01-01T00:00:00Z",
+      },
+      {
+        id: 3,
+        order: 2,
+        content: "# Slide 3",
+        rendered_content: "<h1>Slide 3</h1>",
+        notes: "Notes 3",
+        created_at: "2024-01-01T00:00:00Z",
+        updated_at: "2024-01-01T00:00:00Z",
+      },
+    ],
+    remaining_slide_ids: [4, 5],
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+  };
+
+  const mockSlide4: Slide = {
+    id: 4,
+    order: 3,
+    content: "# Slide 4",
+    rendered_content: "<h1>Slide 4</h1>",
+    notes: null,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+  };
+
+  const mockSlide5: Slide = {
+    id: 5,
+    order: 4,
+    content: "# Slide 5",
+    rendered_content: "<h1>Slide 5</h1>",
+    notes: "Notes 5",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    // Default mock for getSlide to prevent unhandled rejections during background loading
+    vi.mocked(slideshowApi.getSlide).mockResolvedValue({
+      id: 99,
+      order: 99,
+      content: "# Default",
+      rendered_content: "<h1>Default</h1>",
+      notes: null,
+      created_at: "2024-01-01T00:00:00Z",
+      updated_at: "2024-01-01T00:00:00Z",
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("initial loading", () => {
+    it("should start in loading state", () => {
+      vi.mocked(slideshowApi.getSlideshowDetail).mockImplementation(
+        () => new Promise(() => {}), // Never resolves
+      );
+
+      const { result } = renderHook(() => useSlideLoader(1));
+
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.error).toBeNull();
+    });
+
+    it("should call getSlideshowDetail with correct parameters", async () => {
+      vi.mocked(slideshowApi.getSlideshowDetail).mockResolvedValue(
+        mockSlideshowDetail,
+      );
+
+      renderHook(() => useSlideLoader(1));
+
+      await waitFor(() => {
+        expect(slideshowApi.getSlideshowDetail).toHaveBeenCalledWith(1, 3);
+      });
+    });
+
+    it("should set slideCount after loading", async () => {
+      vi.mocked(slideshowApi.getSlideshowDetail).mockResolvedValue(
+        mockSlideshowDetail,
+      );
+
+      const { result } = renderHook(() => useSlideLoader(1));
+
+      await waitFor(() => {
+        expect(result.current.slideCount).toBe(5);
+      });
+    });
+
+    it("should set metadata after loading", async () => {
+      vi.mocked(slideshowApi.getSlideshowDetail).mockResolvedValue(
+        mockSlideshowDetail,
+      );
+
+      const { result } = renderHook(() => useSlideLoader(1));
+
+      await waitFor(() => {
+        expect(result.current.metadata).toEqual({
+          title: "Test Slideshow",
+          author: "testuser",
+          subject: "cs",
+        });
+      });
+    });
+
+    it("should populate initial slides", async () => {
+      vi.mocked(slideshowApi.getSlideshowDetail).mockResolvedValue(
+        mockSlideshowDetail,
+      );
+
+      const { result } = renderHook(() => useSlideLoader(1));
+
+      await waitFor(() => {
+        // Check that initial 3 slides are present (background loading may add more)
+        expect(result.current.slides.size).toBeGreaterThanOrEqual(3);
+        expect(result.current.slides.get(0)?.rendered_content).toBe(
+          "<h1>Slide 1</h1>",
+        );
+        expect(result.current.slides.get(1)?.rendered_content).toBe(
+          "<h1>Slide 2</h1>",
+        );
+        expect(result.current.slides.get(2)?.rendered_content).toBe(
+          "<h1>Slide 3</h1>",
+        );
+      });
+    });
+
+    it("should set isLoading to false after initial load", async () => {
+      vi.mocked(slideshowApi.getSlideshowDetail).mockResolvedValue(
+        mockSlideshowDetail,
+      );
+
+      const { result } = renderHook(() => useSlideLoader(1));
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+    });
+  });
+
+  describe("error handling", () => {
+    it("should set error when API call fails", async () => {
+      vi.mocked(slideshowApi.getSlideshowDetail).mockRejectedValue(
+        new Error("Network error"),
+      );
+
+      const { result } = renderHook(() => useSlideLoader(1));
+
+      await waitFor(() => {
+        expect(result.current.error).toBe("Network error");
+        expect(result.current.isLoading).toBe(false);
+      });
+    });
+
+    it("should handle non-Error rejections", async () => {
+      vi.mocked(slideshowApi.getSlideshowDetail).mockRejectedValue(
+        "String error",
+      );
+
+      const { result } = renderHook(() => useSlideLoader(1));
+
+      await waitFor(() => {
+        expect(result.current.error).toBe("Failed to load slideshow");
+      });
+    });
+  });
+
+  describe("progressive loading", () => {
+    it("should load remaining slides in background", async () => {
+      vi.mocked(slideshowApi.getSlideshowDetail).mockResolvedValue(
+        mockSlideshowDetail,
+      );
+      vi.mocked(slideshowApi.getSlide)
+        .mockResolvedValueOnce(mockSlide4)
+        .mockResolvedValueOnce(mockSlide5);
+
+      const { result } = renderHook(() => useSlideLoader(1));
+
+      // Wait for initial load
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Wait for background loading
+      await waitFor(() => {
+        expect(result.current.slides.size).toBe(5);
+      });
+
+      expect(result.current.slides.get(3)?.rendered_content).toBe(
+        "<h1>Slide 4</h1>",
+      );
+      expect(result.current.slides.get(4)?.rendered_content).toBe(
+        "<h1>Slide 5</h1>",
+      );
+    });
+
+    it("should not call getSlide when no remaining slides", async () => {
+      const noRemainingSlides = {
+        ...mockSlideshowDetail,
+        remaining_slide_ids: [],
+      };
+      vi.mocked(slideshowApi.getSlideshowDetail).mockResolvedValue(
+        noRemainingSlides,
+      );
+
+      renderHook(() => useSlideLoader(1));
+
+      await waitFor(() => {
+        expect(slideshowApi.getSlideshowDetail).toHaveBeenCalled();
+      });
+
+      // Give time for any potential getSlide calls
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(slideshowApi.getSlide).not.toHaveBeenCalled();
+    });
+
+    it("should handle partial failures in background loading gracefully", async () => {
+      vi.mocked(slideshowApi.getSlideshowDetail).mockResolvedValue(
+        mockSlideshowDetail,
+      );
+      vi.mocked(slideshowApi.getSlide)
+        .mockResolvedValueOnce(mockSlide4)
+        .mockRejectedValueOnce(new Error("Failed to load slide 5"));
+
+      const { result } = renderHook(() => useSlideLoader(1));
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Wait for background loading
+      await waitFor(() => {
+        expect(result.current.slides.size).toBe(4); // 3 initial + 1 successful background
+      });
+
+      expect(result.current.slides.has(3)).toBe(true);
+      expect(result.current.slides.has(4)).toBe(false); // Failed to load
+    });
+  });
+
+  describe("isSlideLoaded", () => {
+    it("should return true for loaded slides", async () => {
+      vi.mocked(slideshowApi.getSlideshowDetail).mockResolvedValue(
+        mockSlideshowDetail,
+      );
+
+      const { result } = renderHook(() => useSlideLoader(1));
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.isSlideLoaded(0)).toBe(true);
+      expect(result.current.isSlideLoaded(1)).toBe(true);
+      expect(result.current.isSlideLoaded(2)).toBe(true);
+    });
+
+    it("should return false for unloaded slides", async () => {
+      vi.mocked(slideshowApi.getSlideshowDetail).mockResolvedValue(
+        mockSlideshowDetail,
+      );
+
+      const { result } = renderHook(() => useSlideLoader(1));
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Before background loading completes
+      expect(result.current.isSlideLoaded(3)).toBe(false);
+      expect(result.current.isSlideLoaded(4)).toBe(false);
+    });
+  });
+
+  describe("getLoadedSlides", () => {
+    it("should return array of loaded status", async () => {
+      vi.mocked(slideshowApi.getSlideshowDetail).mockResolvedValue(
+        mockSlideshowDetail,
+      );
+
+      const { result } = renderHook(() => useSlideLoader(1));
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      const loadedSlides = result.current.getLoadedSlides();
+
+      expect(loadedSlides).toHaveLength(5);
+      expect(loadedSlides[0]).toBe(true);
+      expect(loadedSlides[1]).toBe(true);
+      expect(loadedSlides[2]).toBe(true);
+      expect(loadedSlides[3]).toBe(false);
+      expect(loadedSlides[4]).toBe(false);
+    });
+
+    it("should update as slides load", async () => {
+      vi.mocked(slideshowApi.getSlideshowDetail).mockResolvedValue(
+        mockSlideshowDetail,
+      );
+      vi.mocked(slideshowApi.getSlide)
+        .mockResolvedValueOnce(mockSlide4)
+        .mockResolvedValueOnce(mockSlide5);
+
+      const { result } = renderHook(() => useSlideLoader(1));
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      await waitFor(() => {
+        const loadedSlides = result.current.getLoadedSlides();
+        expect(loadedSlides.every((loaded) => loaded)).toBe(true);
+      });
+    });
+  });
+
+  describe("slideshowId changes", () => {
+    it("should reload when slideshowId changes", async () => {
+      const slideshow2: SlideshowDetail = {
+        ...mockSlideshowDetail,
+        id: 2,
+        title: "Slideshow 2",
+        slide_count: 2,
+        slides: [
+          {
+            id: 10,
+            order: 0,
+            content: "# New Slide 1",
+            rendered_content: "<h1>New Slide 1</h1>",
+            notes: null,
+            created_at: "2024-01-01T00:00:00Z",
+            updated_at: "2024-01-01T00:00:00Z",
+          },
+          {
+            id: 11,
+            order: 1,
+            content: "# New Slide 2",
+            rendered_content: "<h1>New Slide 2</h1>",
+            notes: null,
+            created_at: "2024-01-01T00:00:00Z",
+            updated_at: "2024-01-01T00:00:00Z",
+          },
+        ],
+        remaining_slide_ids: [],
+      };
+
+      vi.mocked(slideshowApi.getSlideshowDetail)
+        .mockResolvedValueOnce(mockSlideshowDetail)
+        .mockResolvedValueOnce(slideshow2);
+
+      const { result, rerender } = renderHook(({ id }) => useSlideLoader(id), {
+        initialProps: { id: 1 },
+      });
+
+      await waitFor(() => {
+        expect(result.current.metadata.title).toBe("Test Slideshow");
+      });
+
+      rerender({ id: 2 });
+
+      await waitFor(() => {
+        expect(result.current.metadata.title).toBe("Slideshow 2");
+        expect(result.current.slideCount).toBe(2);
+      });
+    });
+  });
+});

--- a/Frontend/EduLiteFrontend/src/hooks/__tests__/useSlideNavigation.test.ts
+++ b/Frontend/EduLiteFrontend/src/hooks/__tests__/useSlideNavigation.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useSlideNavigation } from "../useSlideNavigation";
+
+describe("useSlideNavigation", () => {
+  describe("initialization", () => {
+    it("should start at initialSlide when provided", () => {
+      const { result } = renderHook(() =>
+        useSlideNavigation({ slideCount: 5, initialSlide: 2 })
+      );
+
+      expect(result.current.currentIndex).toBe(2);
+    });
+
+    it("should default to slide 0 when no initialSlide provided", () => {
+      const { result } = renderHook(() =>
+        useSlideNavigation({ slideCount: 5 })
+      );
+
+      expect(result.current.currentIndex).toBe(0);
+    });
+
+    it("should clamp initialSlide to valid range (too high)", () => {
+      const { result } = renderHook(() =>
+        useSlideNavigation({ slideCount: 5, initialSlide: 10 })
+      );
+
+      expect(result.current.currentIndex).toBe(4); // Last valid index
+    });
+
+    it("should clamp initialSlide to valid range (negative)", () => {
+      const { result } = renderHook(() =>
+        useSlideNavigation({ slideCount: 5, initialSlide: -5 })
+      );
+
+      expect(result.current.currentIndex).toBe(0);
+    });
+
+    it("should handle zero slides", () => {
+      const { result } = renderHook(() =>
+        useSlideNavigation({ slideCount: 0 })
+      );
+
+      expect(result.current.currentIndex).toBe(0);
+      expect(result.current.isFirst).toBe(true);
+      expect(result.current.isLast).toBe(true);
+    });
+  });
+
+  describe("next()", () => {
+    it("should navigate to next slide", () => {
+      const { result } = renderHook(() =>
+        useSlideNavigation({ slideCount: 5, initialSlide: 0 })
+      );
+
+      act(() => {
+        result.current.next();
+      });
+
+      expect(result.current.currentIndex).toBe(1);
+    });
+
+    it("should not go past last slide", () => {
+      const { result } = renderHook(() =>
+        useSlideNavigation({ slideCount: 5, initialSlide: 4 })
+      );
+
+      act(() => {
+        result.current.next();
+      });
+
+      expect(result.current.currentIndex).toBe(4);
+    });
+
+    it("should navigate multiple times", () => {
+      const { result } = renderHook(() =>
+        useSlideNavigation({ slideCount: 5, initialSlide: 0 })
+      );
+
+      act(() => {
+        result.current.next();
+        result.current.next();
+        result.current.next();
+      });
+
+      expect(result.current.currentIndex).toBe(3);
+    });
+  });
+
+  describe("prev()", () => {
+    it("should navigate to previous slide", () => {
+      const { result } = renderHook(() =>
+        useSlideNavigation({ slideCount: 5, initialSlide: 3 })
+      );
+
+      act(() => {
+        result.current.prev();
+      });
+
+      expect(result.current.currentIndex).toBe(2);
+    });
+
+    it("should not go before first slide", () => {
+      const { result } = renderHook(() =>
+        useSlideNavigation({ slideCount: 5, initialSlide: 0 })
+      );
+
+      act(() => {
+        result.current.prev();
+      });
+
+      expect(result.current.currentIndex).toBe(0);
+    });
+
+    it("should navigate multiple times", () => {
+      const { result } = renderHook(() =>
+        useSlideNavigation({ slideCount: 5, initialSlide: 4 })
+      );
+
+      act(() => {
+        result.current.prev();
+        result.current.prev();
+      });
+
+      expect(result.current.currentIndex).toBe(2);
+    });
+  });
+
+  describe("goToSlide()", () => {
+    it("should navigate to specific slide", () => {
+      const { result } = renderHook(() =>
+        useSlideNavigation({ slideCount: 5, initialSlide: 0 })
+      );
+
+      act(() => {
+        result.current.goToSlide(3);
+      });
+
+      expect(result.current.currentIndex).toBe(3);
+    });
+
+    it("should clamp to last slide when index too high", () => {
+      const { result } = renderHook(() =>
+        useSlideNavigation({ slideCount: 5, initialSlide: 0 })
+      );
+
+      act(() => {
+        result.current.goToSlide(100);
+      });
+
+      expect(result.current.currentIndex).toBe(4);
+    });
+
+    it("should clamp to first slide when index negative", () => {
+      const { result } = renderHook(() =>
+        useSlideNavigation({ slideCount: 5, initialSlide: 2 })
+      );
+
+      act(() => {
+        result.current.goToSlide(-10);
+      });
+
+      expect(result.current.currentIndex).toBe(0);
+    });
+
+    it("should handle zero slideCount gracefully", () => {
+      const { result } = renderHook(() =>
+        useSlideNavigation({ slideCount: 0 })
+      );
+
+      act(() => {
+        result.current.goToSlide(5);
+      });
+
+      expect(result.current.currentIndex).toBe(0);
+    });
+  });
+
+  describe("isFirst and isLast", () => {
+    it("should be isFirst when at index 0", () => {
+      const { result } = renderHook(() =>
+        useSlideNavigation({ slideCount: 5, initialSlide: 0 })
+      );
+
+      expect(result.current.isFirst).toBe(true);
+      expect(result.current.isLast).toBe(false);
+    });
+
+    it("should be isLast when at last index", () => {
+      const { result } = renderHook(() =>
+        useSlideNavigation({ slideCount: 5, initialSlide: 4 })
+      );
+
+      expect(result.current.isFirst).toBe(false);
+      expect(result.current.isLast).toBe(true);
+    });
+
+    it("should be both isFirst and isLast with single slide", () => {
+      const { result } = renderHook(() =>
+        useSlideNavigation({ slideCount: 1, initialSlide: 0 })
+      );
+
+      expect(result.current.isFirst).toBe(true);
+      expect(result.current.isLast).toBe(true);
+    });
+
+    it("should update after navigation", () => {
+      const { result } = renderHook(() =>
+        useSlideNavigation({ slideCount: 3, initialSlide: 0 })
+      );
+
+      expect(result.current.isFirst).toBe(true);
+
+      act(() => {
+        result.current.next();
+      });
+
+      expect(result.current.isFirst).toBe(false);
+      expect(result.current.isLast).toBe(false);
+
+      act(() => {
+        result.current.next();
+      });
+
+      expect(result.current.isLast).toBe(true);
+    });
+  });
+
+  describe("slideCount changes", () => {
+    it("should respect new slideCount for bounds", () => {
+      const { result, rerender } = renderHook(
+        ({ slideCount }) => useSlideNavigation({ slideCount, initialSlide: 0 }),
+        { initialProps: { slideCount: 10 } }
+      );
+
+      act(() => {
+        result.current.goToSlide(8);
+      });
+
+      expect(result.current.currentIndex).toBe(8);
+
+      // Reduce slide count - goToSlide should now respect new bounds
+      rerender({ slideCount: 5 });
+
+      // Try to navigate beyond new bounds
+      act(() => {
+        result.current.goToSlide(10);
+      });
+
+      expect(result.current.currentIndex).toBe(4); // Clamped to new max
+    });
+  });
+});

--- a/Frontend/EduLiteFrontend/src/hooks/useKeyboardNavigation.ts
+++ b/Frontend/EduLiteFrontend/src/hooks/useKeyboardNavigation.ts
@@ -1,0 +1,138 @@
+import { useEffect } from "react";
+
+export interface UseKeyboardNavigationOptions {
+  /** Navigate to next slide */
+  onNext: () => void;
+  /** Navigate to previous slide */
+  onPrev: () => void;
+  /** Navigate to specific slide by index */
+  onGoToSlide: (index: number) => void;
+  /** Toggle speaker notes visibility */
+  onToggleNotes: () => void;
+  /** Toggle fullscreen mode */
+  onToggleFullscreen?: () => void;
+  /** Exit the presentation */
+  onExit?: () => void;
+  /** Total number of slides (for number key navigation) */
+  slideCount: number;
+  /** Whether fullscreen is allowed */
+  allowFullscreen?: boolean;
+  /** Whether keyboard navigation is enabled */
+  enabled?: boolean;
+}
+
+/**
+ * Hook for handling keyboard navigation in the slideshow viewer.
+ *
+ * Supports:
+ * - Arrow Right / Space: Next slide
+ * - Arrow Left / Backspace: Previous slide
+ * - Escape: Exit fullscreen or presentation
+ * - N: Toggle speaker notes
+ * - F: Toggle fullscreen (when allowed)
+ * - Home: Go to first slide
+ * - End: Go to last slide
+ * - 1-9: Quick jump to slide (1-indexed)
+ *
+ * @example
+ * ```tsx
+ * useKeyboardNavigation({
+ *   onNext: navigation.next,
+ *   onPrev: navigation.prev,
+ *   onGoToSlide: navigation.goToSlide,
+ *   onToggleNotes: () => setShowNotes(prev => !prev),
+ *   onToggleFullscreen: presentation.toggleFullscreen,
+ *   onExit: handleExit,
+ *   slideCount: 10,
+ *   allowFullscreen: true,
+ * });
+ * ```
+ */
+export function useKeyboardNavigation({
+  onNext,
+  onPrev,
+  onGoToSlide,
+  onToggleNotes,
+  onToggleFullscreen,
+  onExit,
+  slideCount,
+  allowFullscreen = false,
+  enabled = true,
+}: UseKeyboardNavigationOptions): void {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      switch (e.key) {
+        case "ArrowRight":
+        case " ":
+          e.preventDefault();
+          onNext();
+          break;
+
+        case "ArrowLeft":
+        case "Backspace":
+          e.preventDefault();
+          onPrev();
+          break;
+
+        case "Escape":
+          e.preventDefault();
+          if (document.fullscreenElement) {
+            document.exitFullscreen();
+          } else {
+            onExit?.();
+          }
+          break;
+
+        case "n":
+        case "N":
+          e.preventDefault();
+          onToggleNotes();
+          break;
+
+        case "Home":
+          e.preventDefault();
+          onGoToSlide(0);
+          break;
+
+        case "End":
+          e.preventDefault();
+          onGoToSlide(slideCount - 1);
+          break;
+
+        case "f":
+        case "F":
+          if (allowFullscreen && onToggleFullscreen) {
+            e.preventDefault();
+            onToggleFullscreen();
+          }
+          break;
+
+        default:
+          // Number keys (1-9) for quick jump
+          if (e.key >= "1" && e.key <= "9") {
+            const slideNum = parseInt(e.key, 10) - 1; // Convert to 0-indexed
+            if (slideNum < slideCount) {
+              e.preventDefault();
+              onGoToSlide(slideNum);
+            }
+          }
+          break;
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [
+    onNext,
+    onPrev,
+    onGoToSlide,
+    onToggleNotes,
+    onToggleFullscreen,
+    onExit,
+    slideCount,
+    allowFullscreen,
+    enabled,
+  ]);
+}

--- a/Frontend/EduLiteFrontend/src/hooks/usePresentationMode.ts
+++ b/Frontend/EduLiteFrontend/src/hooks/usePresentationMode.ts
@@ -1,0 +1,178 @@
+import { useState, useEffect, useCallback, RefObject } from "react";
+
+export interface UsePresentationModeOptions {
+  /** Ref to the container element for fullscreen */
+  containerRef: RefObject<HTMLElement | null>;
+  /** Whether notes panel is open (affects bottom bar hover threshold) */
+  showNotes?: boolean;
+  /** Whether settings modal is open (keeps top bar visible) */
+  settingsOpen?: boolean;
+  /** Whether help modal is open (keeps top bar visible) */
+  helpOpen?: boolean;
+}
+
+export interface UsePresentationModeReturn {
+  /** Whether currently in fullscreen mode */
+  isFullscreen: boolean;
+  /** Toggle fullscreen on/off */
+  toggleFullscreen: () => Promise<void>;
+  /** Whether top bar should be visible */
+  shouldShowTopBar: boolean;
+  /** Whether bottom bar should be visible */
+  shouldShowBottomBar: boolean;
+  /** Whether top bar auto-hide is enabled */
+  autoHideTopBar: boolean;
+  /** Set top bar auto-hide setting */
+  setAutoHideTopBar: (value: boolean) => void;
+  /** Whether bottom bar auto-hide is enabled */
+  autoHideBottomBar: boolean;
+  /** Set bottom bar auto-hide setting */
+  setAutoHideBottomBar: (value: boolean) => void;
+}
+
+const STORAGE_KEY_TOP = "slideshow-auto-hide-top";
+const STORAGE_KEY_BOTTOM = "slideshow-auto-hide-bottom";
+
+/**
+ * Hook for managing presentation mode features including fullscreen
+ * and auto-hiding UI bars.
+ *
+ * @example
+ * ```tsx
+ * const containerRef = useRef<HTMLDivElement>(null);
+ * const {
+ *   isFullscreen,
+ *   toggleFullscreen,
+ *   shouldShowTopBar,
+ *   shouldShowBottomBar,
+ *   autoHideTopBar,
+ *   setAutoHideTopBar,
+ *   autoHideBottomBar,
+ *   setAutoHideBottomBar,
+ * } = usePresentationMode({ containerRef, showNotes });
+ * ```
+ */
+export function usePresentationMode({
+  containerRef,
+  showNotes = false,
+  settingsOpen = false,
+  helpOpen = false,
+}: UsePresentationModeOptions): UsePresentationModeReturn {
+  // Fullscreen state
+  const [isFullscreen, setIsFullscreen] = useState<boolean>(false);
+
+  // Auto-hide settings (persisted to localStorage)
+  const [autoHideTopBar, setAutoHideTopBarState] = useState<boolean>(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY_TOP);
+      return saved !== null ? JSON.parse(saved) : true;
+    } catch {
+      return true;
+    }
+  });
+
+  const [autoHideBottomBar, setAutoHideBottomBarState] = useState<boolean>(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY_BOTTOM);
+      return saved !== null ? JSON.parse(saved) : true;
+    } catch {
+      return true;
+    }
+  });
+
+  // Hover state for auto-hide
+  const [isTopBarHovered, setIsTopBarHovered] = useState<boolean>(false);
+  const [isBottomBarHovered, setIsBottomBarHovered] = useState<boolean>(false);
+
+  // Persist auto-hide settings
+  const setAutoHideTopBar = useCallback((value: boolean) => {
+    setAutoHideTopBarState(value);
+    try {
+      localStorage.setItem(STORAGE_KEY_TOP, JSON.stringify(value));
+    } catch {
+      // localStorage may be unavailable
+    }
+  }, []);
+
+  const setAutoHideBottomBar = useCallback((value: boolean) => {
+    setAutoHideBottomBarState(value);
+    try {
+      localStorage.setItem(STORAGE_KEY_BOTTOM, JSON.stringify(value));
+    } catch {
+      // localStorage may be unavailable
+    }
+  }, []);
+
+  // Track mouse position for auto-hide
+  useEffect(() => {
+    const handleMouseMove = (e: MouseEvent) => {
+      const baseThreshold = 100; // pixels from edge to trigger show
+
+      // Top bar
+      if (autoHideTopBar) {
+        setIsTopBarHovered(e.clientY < baseThreshold);
+      } else {
+        setIsTopBarHovered(true);
+      }
+
+      // Bottom bar - adjust threshold based on notes being open
+      if (autoHideBottomBar) {
+        // When notes are open, extend threshold to cover:
+        // - Notes content: max-h-80 (320px) + padding/borders (~20px)
+        // - Toggle button: ~48px
+        // - Progress bar: ~50px
+        // Total: ~440px, use 450px to be safe
+        const bottomThreshold = showNotes ? 450 : baseThreshold;
+        setIsBottomBarHovered(e.clientY > window.innerHeight - bottomThreshold);
+      } else {
+        setIsBottomBarHovered(true);
+      }
+    };
+
+    window.addEventListener("mousemove", handleMouseMove);
+    return () => window.removeEventListener("mousemove", handleMouseMove);
+  }, [autoHideTopBar, autoHideBottomBar, showNotes]);
+
+  // Toggle fullscreen
+  const toggleFullscreen = useCallback(async () => {
+    if (!containerRef.current) return;
+
+    try {
+      if (!document.fullscreenElement) {
+        await containerRef.current.requestFullscreen();
+        setIsFullscreen(true);
+      } else {
+        await document.exitFullscreen();
+        setIsFullscreen(false);
+      }
+    } catch (err) {
+      console.error("Fullscreen error:", err);
+      throw err; // Let caller handle the error (e.g., show toast)
+    }
+  }, [containerRef]);
+
+  // Listen for fullscreen changes (e.g., user presses Esc)
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      setIsFullscreen(!!document.fullscreenElement);
+    };
+
+    document.addEventListener("fullscreenchange", handleFullscreenChange);
+    return () => document.removeEventListener("fullscreenchange", handleFullscreenChange);
+  }, []);
+
+  // Compute whether bars should be visible
+  const shouldShowTopBar = !autoHideTopBar || isTopBarHovered || settingsOpen || helpOpen;
+  const shouldShowBottomBar = !autoHideBottomBar || isBottomBarHovered;
+
+  return {
+    isFullscreen,
+    toggleFullscreen,
+    shouldShowTopBar,
+    shouldShowBottomBar,
+    autoHideTopBar,
+    setAutoHideTopBar,
+    autoHideBottomBar,
+    setAutoHideBottomBar,
+  };
+}

--- a/Frontend/EduLiteFrontend/src/hooks/useSlideLoader.ts
+++ b/Frontend/EduLiteFrontend/src/hooks/useSlideLoader.ts
@@ -1,0 +1,168 @@
+import { useState, useEffect } from "react";
+import toast from "react-hot-toast";
+import { getSlideshowDetail, getSlide } from "../services/slideshowApi";
+import type { Slide, SlideViewOnly } from "../types/slideshow.types";
+
+export interface SlideshowMetadata {
+  /** Slideshow title */
+  title: string;
+  /** Author's username */
+  author: string;
+  /** Subject code (e.g., 'cs', 'math') */
+  subject: string | null;
+}
+
+export interface UseSlideLoaderReturn {
+  /** Map of slides indexed by order */
+  slides: Map<number, Slide | SlideViewOnly>;
+  /** Total number of slides */
+  slideCount: number;
+  /** Whether initial slides are loading */
+  isLoading: boolean;
+  /** Error message if loading failed */
+  error: string | null;
+  /** Slideshow metadata */
+  metadata: SlideshowMetadata;
+  /** Check if a specific slide is loaded */
+  isSlideLoaded: (index: number) => boolean;
+  /** Get array of loaded status for all slides */
+  getLoadedSlides: () => boolean[];
+}
+
+/**
+ * Hook for loading slideshow data with progressive loading.
+ *
+ * Initially loads the first 3 slides, then loads remaining slides
+ * in the background in batches.
+ *
+ * @example
+ * ```tsx
+ * const {
+ *   slides,
+ *   slideCount,
+ *   isLoading,
+ *   error,
+ *   metadata,
+ *   isSlideLoaded,
+ * } = useSlideLoader(slideshowId);
+ * ```
+ */
+export function useSlideLoader(slideshowId: number): UseSlideLoaderReturn {
+  const [slides, setSlides] = useState<Map<number, Slide | SlideViewOnly>>(
+    new Map()
+  );
+  const [slideCount, setSlideCount] = useState<number>(0);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const [metadata, setMetadata] = useState<SlideshowMetadata>({
+    title: "",
+    author: "",
+    subject: null,
+  });
+  const [remainingSlideIds, setRemainingSlideIds] = useState<number[]>([]);
+
+  /**
+   * Initial load: Fetch first 3 slides immediately
+   */
+  useEffect(() => {
+    const loadInitialSlides = async () => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        // Fetch first 3 slides
+        const data = await getSlideshowDetail(slideshowId, 3);
+
+        // Store slideshow metadata
+        setSlideCount(data.slide_count);
+        setMetadata({
+          title: data.title,
+          author: data.created_by_username,
+          subject: data.subject,
+        });
+        setRemainingSlideIds(data.remaining_slide_ids);
+
+        // Store initial slides in Map (indexed by order)
+        const initialSlides = new Map<number, Slide | SlideViewOnly>();
+        data.slides.forEach((slide) => {
+          initialSlides.set(slide.order, slide);
+        });
+        setSlides(initialSlides);
+
+        setIsLoading(false);
+      } catch (err) {
+        console.error("Failed to load slideshow:", err);
+        const errorMessage =
+          err instanceof Error ? err.message : "Failed to load slideshow";
+        setError(errorMessage);
+        setIsLoading(false);
+        toast.error("Failed to load slideshow");
+      }
+    };
+
+    loadInitialSlides();
+  }, [slideshowId]);
+
+  /**
+   * Background loading: Fetch remaining slides progressively
+   */
+  useEffect(() => {
+    if (remainingSlideIds.length === 0) return;
+
+    const loadRemainingSlides = async () => {
+      // Load remaining slides in parallel (batch of 5 at a time)
+      const batchSize = 5;
+      const idsToLoad = [...remainingSlideIds];
+
+      for (let i = 0; i < idsToLoad.length; i += batchSize) {
+        const batch = idsToLoad.slice(i, i + batchSize);
+
+        // Fetch batch in parallel
+        const promises = batch.map((slideId) =>
+          getSlide(slideshowId, slideId)
+            .then((slide) => ({ slideId, slide, error: null }))
+            .catch((fetchError) => ({ slideId, slide: null, error: fetchError }))
+        );
+
+        const results = await Promise.all(promises);
+
+        // Store fetched slides
+        setSlides((prev) => {
+          const newMap = new Map(prev);
+          results.forEach(({ slide }) => {
+            if (slide) {
+              newMap.set(slide.order, slide);
+            }
+          });
+          return newMap;
+        });
+      }
+    };
+
+    loadRemainingSlides();
+  }, [remainingSlideIds, slideshowId]);
+
+  /**
+   * Check if a specific slide is loaded
+   */
+  const isSlideLoaded = (index: number): boolean => {
+    return slides.has(index);
+  };
+
+  /**
+   * Get array of loaded status for all slides
+   */
+  const getLoadedSlides = (): boolean[] => {
+    return Array.from({ length: slideCount }, (_, i) => slides.has(i));
+  };
+
+  return {
+    slides,
+    slideCount,
+    isLoading,
+    error,
+    metadata,
+    isSlideLoaded,
+    getLoadedSlides,
+  };
+}

--- a/Frontend/EduLiteFrontend/src/hooks/useSlideNavigation.ts
+++ b/Frontend/EduLiteFrontend/src/hooks/useSlideNavigation.ts
@@ -1,0 +1,80 @@
+import { useState, useCallback } from "react";
+
+export interface UseSlideNavigationOptions {
+  /** Total number of slides */
+  slideCount: number;
+  /** Initial slide index (0-based) */
+  initialSlide?: number;
+}
+
+export interface UseSlideNavigationReturn {
+  /** Current slide index (0-based) */
+  currentIndex: number;
+  /** Navigate to a specific slide by index */
+  goToSlide: (index: number) => void;
+  /** Navigate to the next slide */
+  next: () => void;
+  /** Navigate to the previous slide */
+  prev: () => void;
+  /** Whether currently on the first slide */
+  isFirst: boolean;
+  /** Whether currently on the last slide */
+  isLast: boolean;
+}
+
+/**
+ * Hook for managing slide navigation state and actions.
+ *
+ * Provides navigation functions with automatic bounds checking.
+ *
+ * @example
+ * ```tsx
+ * const { currentIndex, next, prev, isFirst, isLast } = useSlideNavigation({
+ *   slideCount: 10,
+ *   initialSlide: 0,
+ * });
+ * ```
+ */
+export function useSlideNavigation({
+  slideCount,
+  initialSlide = 0,
+}: UseSlideNavigationOptions): UseSlideNavigationReturn {
+  // Start with initialSlide - don't clamp during initialization
+  // This allows the initial slide to be set before slideCount is known
+  const [currentIndex, setCurrentIndex] = useState<number>(
+    Math.max(0, initialSlide),
+  );
+
+  const goToSlide = useCallback(
+    (index: number) => {
+      if (slideCount === 0) return;
+      setCurrentIndex(Math.max(0, Math.min(index, slideCount - 1)));
+    },
+    [slideCount],
+  );
+
+  const next = useCallback(() => {
+    if (slideCount === 0) return;
+    setCurrentIndex((prev) => Math.min(prev + 1, slideCount - 1));
+  }, [slideCount]);
+
+  const prev = useCallback(() => {
+    setCurrentIndex((prev) => Math.max(prev - 1, 0));
+  }, []);
+
+  // Clamp currentIndex to valid range for consumers
+  // This ensures that when slideCount changes, the index is always valid
+  const effectiveIndex =
+    slideCount === 0 ? currentIndex : Math.min(currentIndex, slideCount - 1);
+  const isFirst = effectiveIndex === 0;
+  const isLast = slideCount === 0 ? true : effectiveIndex === slideCount - 1;
+
+  return {
+    currentIndex: effectiveIndex,
+    goToSlide,
+    next,
+    prev,
+    isFirst,
+    isLast,
+  };
+}


### PR DESCRIPTION
# Refactor: Decompose SlideshowViewer into Custom Hooks

Closes #202

## Summary

Refactored the `SlideshowViewer` component from 643 lines with 13+ intertwined useState hooks into a cleaner architecture using 4 focused custom hooks. The component is now 450 lines (30% reduction) with clear separation of concerns.

## Changes

### New Hooks Created

| Hook | Lines | Purpose |
|------|-------|---------|
| `useSlideNavigation` | 80 | Manages slide index, next/prev/goToSlide with bounds checking |
| `useSlideLoader` | 168 | Handles API calls, progressive loading, metadata |
| `usePresentationMode` | 178 | Fullscreen API, auto-hide bars, localStorage persistence |
| `useKeyboardNavigation` | 138 | Keyboard shortcuts (arrows, space, N, F, Home/End, 1-9) |

### New Test Files

| Test File | Tests | Coverage |
|-----------|-------|----------|
| `useSlideNavigation.test.ts` | 20 | Initialization, navigation, bounds, edge cases |
| `useSlideLoader.test.ts` | 16 | Loading states, errors, progressive loading |
| `usePresentationMode.test.ts` | 21 | Fullscreen, auto-hide, localStorage, mouse tracking |
| `useKeyboardNavigation.test.ts` | 21 | All keyboard shortcuts, enabled/disabled states |

### Modified Files

- `SlideshowViewer.tsx` - Now uses the 4 custom hooks instead of inline state management

## Before/After

**Before:**
```tsx
// 643 lines, 13+ useState hooks
const [currentIndex, setCurrentIndex] = useState(initialSlide);
const [slides, setSlides] = useState(new Map());
const [showNotes, setShowNotes] = useState(showNotesInitial);
const [isLoading, setIsLoading] = useState(true);
const [error, setError] = useState(null);
const [isFullscreen, setIsFullscreen] = useState(false);
// ... 7 more state variables
```

**After:**
```tsx
// 450 lines, clean separation of concerns
const { slides, slideCount, isLoading, error, metadata } = useSlideLoader(slideshowId);
const navigation = useSlideNavigation({ slideCount, initialSlide });
const presentation = usePresentationMode({ containerRef, showNotes, settingsOpen, helpOpen });

useKeyboardNavigation({
  onNext: navigation.next,
  onPrev: navigation.prev,
  onGoToSlide: navigation.goToSlide,
  onToggleNotes: toggleNotes,
  onToggleFullscreen: handleToggleFullscreen,
  onExit,
  slideCount,
  allowFullscreen,
});
```

## Benefits

1. **Clarity** - Each hook does one thing, easy to understand in isolation
2. **Testability** - Can unit test navigation logic without rendering the full component
3. **Reusability** - `useSlideNavigation` could be reused for carousels, image galleries, etc.
4. **Maintainability** - Bug in fullscreen? Look at `usePresentationMode`, not 600+ lines

## Testing

- All 488 existing tests pass
- 78 new unit tests for the custom hooks
- TypeScript compiles without errors
- Original `SlideshowViewer.test.tsx` unchanged and passing (proves external API preserved)

## Files Changed

**Created:**
- `src/hooks/useSlideNavigation.ts`
- `src/hooks/useSlideLoader.ts`
- `src/hooks/usePresentationMode.ts`
- `src/hooks/useKeyboardNavigation.ts`
- `src/hooks/__tests__/useSlideNavigation.test.ts`
- `src/hooks/__tests__/useSlideLoader.test.ts`
- `src/hooks/__tests__/usePresentationMode.test.ts`
- `src/hooks/__tests__/useKeyboardNavigation.test.ts`

**Modified:**
- `src/components/slideshow/SlideshowViewer.tsx`
