### PR TITLE
Spellblocks Toolbar Dropdown + Slideshow Bug Fixes

### DIFF
--- a/Frontend/EduLiteFrontend/src/components/slideshow/SlideshowViewer.tsx
+++ b/Frontend/EduLiteFrontend/src/components/slideshow/SlideshowViewer.tsx
@@ -380,22 +380,34 @@ const SlideshowViewer: React.FC<SlideshowViewerProps> = ({
         </div>
 
         {/* Navigation Arrows (always visible on desktop) */}
-        <div className="absolute left-4 top-1/2 -translate-y-1/2 hidden md:block">
+        <div className="absolute left-4 top-1/2 -translate-y-1/2 hidden md:block pointer-events-none z-10">
           <button
             onClick={navigation.prev}
+            onWheel={(e) => {
+              const scrollable = containerRef.current?.querySelector(
+                '[class*="overflow-y"]',
+              );
+              if (scrollable) scrollable.scrollTop += e.deltaY;
+            }}
             disabled={navigation.isFirst}
-            className="p-4 rounded-full bg-white/90 dark:bg-gray-800/90 hover:bg-white dark:hover:bg-gray-700 backdrop-blur-lg text-gray-900 dark:text-gray-100 hover:text-gray-900 dark:hover:text-white transition-all disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer shadow-lg"
+            className="p-4 rounded-full bg-white/90 dark:bg-gray-800/90 hover:bg-white dark:hover:bg-gray-700 backdrop-blur-lg text-gray-900 dark:text-gray-100 hover:text-gray-900 dark:hover:text-white transition-all disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer shadow-lg pointer-events-auto"
             aria-label="Previous slide"
           >
             <HiArrowLeft className="w-6 h-6" />
           </button>
         </div>
 
-        <div className="absolute right-4 top-1/2 -translate-y-1/2 hidden md:block">
+        <div className="absolute right-4 top-1/2 -translate-y-1/2 hidden md:block pointer-events-none z-10">
           <button
             onClick={navigation.next}
+            onWheel={(e) => {
+              const scrollable = containerRef.current?.querySelector(
+                '[class*="overflow-y"]',
+              );
+              if (scrollable) scrollable.scrollTop += e.deltaY;
+            }}
             disabled={navigation.isLast}
-            className="p-4 rounded-full bg-white/90 dark:bg-gray-800/90 hover:bg-white dark:hover:bg-gray-700 backdrop-blur-lg text-gray-900 dark:text-gray-100 hover:text-gray-900 dark:hover:text-white transition-all disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer shadow-lg"
+            className="p-4 rounded-full bg-white/90 dark:bg-gray-800/90 hover:bg-white dark:hover:bg-gray-700 backdrop-blur-lg text-gray-900 dark:text-gray-100 hover:text-gray-900 dark:hover:text-white transition-all disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer shadow-lg pointer-events-auto"
             aria-label="Next slide"
           >
             <HiArrowRight className="w-6 h-6" />

--- a/Frontend/EduLiteFrontend/src/components/slideshow/editor/EditorToolbar.tsx
+++ b/Frontend/EduLiteFrontend/src/components/slideshow/editor/EditorToolbar.tsx
@@ -1,9 +1,12 @@
-import { RefObject } from 'react';
+import { RefObject, useState, useEffect, useRef } from "react";
 import {
   HiCode,
   HiLink,
   HiPhotograph,
-} from 'react-icons/hi';
+  HiPuzzle,
+  HiChevronDown,
+} from "react-icons/hi";
+import { HiRectangleGroup } from "react-icons/hi2";
 
 interface EditorToolbarProps {
   textareaRef: RefObject<HTMLTextAreaElement | null>;
@@ -11,16 +14,76 @@ interface EditorToolbarProps {
 }
 
 export function EditorToolbar({ textareaRef, onInsert }: EditorToolbarProps) {
-  const handleBold = () => onInsert('**', '**', 'bold text');
-  const handleItalic = () => onInsert('_', '_', 'italic text');
-  const handleH1 = () => insertAtLineStart('# ');
-  const handleH2 = () => insertAtLineStart('## ');
-  const handleH3 = () => insertAtLineStart('### ');
-  const handleBulletList = () => insertAtLineStart('- ');
-  const handleNumberedList = () => insertAtLineStart('1. ');
-  const handleLink = () => onInsert('[', '](url)', 'link text');
-  const handleImage = () => onInsert('![', '](url)', 'alt text');
-  const handleCodeBlock = () => onInsert('\n```\n', '\n```\n', 'code here');
+  const [showSpellblocks, setShowSpellblocks] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Spellblock insert handlers
+  const handleInsertCard = () => {
+    onInsert(
+      '\n{~ card title="Card Title" footer="Optional Footer" ~}\n',
+      "\n{~~}\n",
+      "Your content here",
+    );
+    setShowSpellblocks(false);
+  };
+
+  const handleInsertAccordion = () => {
+    onInsert(
+      '\n{~ accordion title="Accordion Title" open=false ~}\n',
+      "\n{~~}\n",
+      "Your content here",
+    );
+    setShowSpellblocks(false);
+  };
+
+  // Close dropdown on click outside
+  useEffect(() => {
+    if (!showSpellblocks) return;
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(e.target as Node)
+      ) {
+        setShowSpellblocks(false);
+      }
+    };
+
+    // Use timeout to avoid immediate close from the button click
+    const timeoutId = setTimeout(() => {
+      document.addEventListener("click", handleClickOutside);
+    }, 0);
+
+    return () => {
+      clearTimeout(timeoutId);
+      document.removeEventListener("click", handleClickOutside);
+    };
+  }, [showSpellblocks]);
+
+  // Close dropdown on Escape
+  useEffect(() => {
+    if (!showSpellblocks) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setShowSpellblocks(false);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [showSpellblocks]);
+
+  const handleBold = () => onInsert("**", "**", "bold text");
+  const handleItalic = () => onInsert("_", "_", "italic text");
+  const handleH1 = () => insertAtLineStart("# ");
+  const handleH2 = () => insertAtLineStart("## ");
+  const handleH3 = () => insertAtLineStart("### ");
+  const handleBulletList = () => insertListAtLineStart("- ", "unordered");
+  const handleNumberedList = () => insertListAtLineStart("1. ", "ordered");
+  const handleLink = () => onInsert("[", "](url)", "link text");
+  const handleImage = () => onInsert("![", "](url)", "alt text");
+  const handleCodeBlock = () => onInsert("\n```\n", "\n```\n", "code here");
 
   const insertAtLineStart = (text: string) => {
     const textarea = textareaRef.current;
@@ -30,7 +93,7 @@ export function EditorToolbar({ textareaRef, onInsert }: EditorToolbarProps) {
     const value = textarea.value;
 
     // Find the start of the current line
-    const lineStart = value.lastIndexOf('\n', start - 1) + 1;
+    const lineStart = value.lastIndexOf("\n", start - 1) + 1;
 
     // Insert text at line start
     const before = value.substring(0, lineStart);
@@ -42,21 +105,106 @@ export function EditorToolbar({ textareaRef, onInsert }: EditorToolbarProps) {
     textarea.focus();
 
     // Trigger change event
-    const event = new Event('input', { bubbles: true });
+    const event = new Event("input", { bubbles: true });
+    textarea.dispatchEvent(event);
+  };
+
+  // List patterns
+  const UNORDERED_LIST_REGEX = /^(\s*)([-*+])\s/;
+  const ORDERED_LIST_REGEX = /^(\s*)(\d+)\.\s/;
+
+  const insertListAtLineStart = (
+    text: string,
+    listType: "ordered" | "unordered",
+  ) => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+
+    const start = textarea.selectionStart;
+    const value = textarea.value;
+
+    // Find the current line
+    const lineStart = value.lastIndexOf("\n", start - 1) + 1;
+    const lineEnd = value.indexOf("\n", start);
+    const currentLine = value.substring(
+      lineStart,
+      lineEnd === -1 ? value.length : lineEnd,
+    );
+
+    // Check if we're already in a list
+    const unorderedMatch = currentLine.match(UNORDERED_LIST_REGEX);
+    const orderedMatch = currentLine.match(ORDERED_LIST_REGEX);
+
+    const currentListType = unorderedMatch
+      ? "unordered"
+      : orderedMatch
+        ? "ordered"
+        : null;
+
+    // If we're in a different list type, nest it (add indent)
+    if (currentListType && currentListType !== listType) {
+      // Get current indentation
+      const currentIndent = unorderedMatch
+        ? unorderedMatch[1]
+        : orderedMatch
+          ? orderedMatch[1]
+          : "";
+      const newIndent = currentIndent + "  "; // Add 2 spaces for nesting
+
+      // Insert nested list on new line
+      const insertion = `\n${newIndent}${text}`;
+      const newValue =
+        value.substring(0, start) + insertion + value.substring(start);
+
+      textarea.value = newValue;
+      textarea.selectionStart = textarea.selectionEnd =
+        start + insertion.length;
+      textarea.focus();
+
+      const event = new Event("input", { bubbles: true });
+      textarea.dispatchEvent(event);
+      return;
+    }
+
+    // Otherwise, just insert at line start as normal
+    const before = value.substring(0, lineStart);
+    const after = value.substring(lineStart);
+    const newValue = before + text + after;
+
+    textarea.value = newValue;
+    textarea.selectionStart = textarea.selectionEnd = lineStart + text.length;
+    textarea.focus();
+
+    const event = new Event("input", { bubbles: true });
     textarea.dispatchEvent(event);
   };
 
   const buttons = [
-    { icon: 'B', label: 'Bold (Ctrl+B)', onClick: handleBold, isText: true },
-    { icon: 'I', label: 'Italic (Ctrl+I)', onClick: handleItalic, isText: true },
-    { icon: 'H1', label: 'Heading 1', onClick: handleH1, isText: true },
-    { icon: 'H2', label: 'Heading 2', onClick: handleH2, isText: true },
-    { icon: 'H3', label: 'Heading 3', onClick: handleH3, isText: true },
-    { icon: '•', label: 'Bullet List', onClick: handleBulletList, isText: true },
-    { icon: '1.', label: 'Numbered List', onClick: handleNumberedList, isText: true },
-    { icon: HiLink, label: 'Link', onClick: handleLink },
-    { icon: HiPhotograph, label: 'Image', onClick: handleImage },
-    { icon: HiCode, label: 'Code Block', onClick: handleCodeBlock },
+    { icon: "B", label: "Bold (Ctrl+B)", onClick: handleBold, isText: true },
+    {
+      icon: "I",
+      label: "Italic (Ctrl+I)",
+      onClick: handleItalic,
+      isText: true,
+    },
+    { icon: "H1", label: "Heading 1", onClick: handleH1, isText: true },
+    { icon: "H2", label: "Heading 2", onClick: handleH2, isText: true },
+    { icon: "H3", label: "Heading 3", onClick: handleH3, isText: true },
+    {
+      icon: "•",
+      label: "Bullet List",
+      onClick: handleBulletList,
+      isText: true,
+    },
+    {
+      icon: "1.",
+      label: "Numbered List",
+      onClick: handleNumberedList,
+      isText: true,
+    },
+    { icon: HiLink, label: "Link", onClick: handleLink },
+    { icon: HiPhotograph, label: "Image", onClick: handleImage },
+    { icon: HiCode, label: "Code Block", onClick: handleCodeBlock },
   ];
 
   return (
@@ -82,6 +230,44 @@ export function EditorToolbar({ textareaRef, onInsert }: EditorToolbarProps) {
           </button>
         );
       })}
+
+      {/* Spellblocks Dropdown */}
+      <div ref={dropdownRef} className="relative">
+        <button
+          type="button"
+          onClick={() => setShowSpellblocks(!showSpellblocks)}
+          title="Spellblocks"
+          className={`p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white cursor-pointer flex items-center gap-1 ${
+            showSpellblocks ? "bg-gray-100 dark:bg-gray-800" : ""
+          }`}
+        >
+          <HiPuzzle className="w-5 h-5" />
+          <HiChevronDown
+            className={`w-3 h-3 transition-transform ${showSpellblocks ? "rotate-180" : ""}`}
+          />
+        </button>
+
+        {showSpellblocks && (
+          <div className="absolute top-full left-0 mt-1 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 py-1 min-w-[160px] z-50">
+            <button
+              type="button"
+              onClick={handleInsertCard}
+              className="w-full px-4 py-2 text-left text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors cursor-pointer flex items-center gap-2"
+            >
+              <HiRectangleGroup className="w-4 h-4" />
+              Card
+            </button>
+            <button
+              type="button"
+              onClick={handleInsertAccordion}
+              className="w-full px-4 py-2 text-left text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors cursor-pointer flex items-center gap-2"
+            >
+              <HiChevronDown className="w-4 h-4" />
+              Accordion
+            </button>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/Frontend/EduLiteFrontend/src/components/slideshow/editor/SlideList.tsx
+++ b/Frontend/EduLiteFrontend/src/components/slideshow/editor/SlideList.tsx
@@ -6,17 +6,17 @@ import {
   useSensor,
   useSensors,
   DragEndEvent,
-} from '@dnd-kit/core';
+} from "@dnd-kit/core";
 import {
   arrayMove,
   SortableContext,
   sortableKeyboardCoordinates,
   useSortable,
   verticalListSortingStrategy,
-} from '@dnd-kit/sortable';
-import { CSS } from '@dnd-kit/utilities';
-import { HiMenu, HiTrash, HiDuplicate } from 'react-icons/hi';
-import type { EditorSlide } from '../../../types/editor.types';
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { HiMenu, HiTrash, HiDuplicate } from "react-icons/hi";
+import type { EditorSlide } from "../../../types/editor.types";
 
 interface SlideListProps {
   slides: EditorSlide[];
@@ -58,27 +58,39 @@ function SortableSlideItem({
     opacity: isDragging ? 0.5 : 1,
   };
 
-  const preview = slide.content.split('\n')[0].replace(/^#+\s*/, '').substring(0, 50) || 'Empty slide';
+  const preview =
+    slide.content
+      .split("\n")[0]
+      .replace(/^#+\s*/, "")
+      .substring(0, 50) || "Empty slide";
 
   return (
     <div ref={setNodeRef} style={style} className={`group relative`}>
       <div
         className={`flex items-start gap-2 p-3 border rounded-lg cursor-pointer transition-all ${
           isSelected
-            ? 'bg-blue-50 dark:bg-blue-900/20 border-blue-500'
-            : 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600'
+            ? "bg-blue-50 dark:bg-blue-900/20 border-blue-500"
+            : "bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600"
         }`}
         onClick={onSelect}
       >
-        <div {...attributes} {...listeners} className="cursor-grab active:cursor-grabbing pt-1">
+        <div
+          {...attributes}
+          {...listeners}
+          className="cursor-grab active:cursor-grabbing pt-1"
+        >
           <HiMenu className="w-4 h-4 text-gray-400" />
         </div>
 
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 mb-1">
-            <span className="text-xs font-semibold text-gray-500">Slide {index + 1}</span>
+            <span className="text-xs font-semibold text-gray-500">
+              Slide {index + 1}
+            </span>
           </div>
-          <p className="text-sm text-gray-700 dark:text-gray-300 truncate">{preview}</p>
+          <p className="text-sm text-gray-700 dark:text-gray-300 truncate">
+            {preview}
+          </p>
         </div>
 
         <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
@@ -88,7 +100,7 @@ function SortableSlideItem({
               e.stopPropagation();
               onDuplicate();
             }}
-            className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
+            className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer"
             title="Duplicate"
           >
             <HiDuplicate className="w-4 h-4 text-gray-500" />
@@ -99,7 +111,7 @@ function SortableSlideItem({
               e.stopPropagation();
               onDelete();
             }}
-            className="p-1 rounded hover:bg-red-100 dark:hover:bg-red-900/20"
+            className="p-1 rounded hover:bg-red-100 dark:hover:bg-red-900/20 cursor-pointer"
             title="Delete"
           >
             <HiTrash className="w-4 h-4 text-red-500" />
@@ -120,10 +132,14 @@ export function SlideList({
   onDuplicate,
 }: SlideListProps) {
   const sensors = useSensors(
-    useSensor(PointerSensor),
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 8,
+      },
+    }),
     useSensor(KeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,
-    })
+    }),
   );
 
   const handleDragEnd = (event: DragEndEvent) => {
@@ -132,10 +148,12 @@ export function SlideList({
     if (over && active.id !== over.id) {
       const oldIndex = slides.findIndex((s) => s.tempId === active.id);
       const newIndex = slides.findIndex((s) => s.tempId === over.id);
-      const reordered = arrayMove(slides, oldIndex, newIndex).map((slide, index) => ({
-        ...slide,
-        order: index,
-      }));
+      const reordered = arrayMove(slides, oldIndex, newIndex).map(
+        (slide, index) => ({
+          ...slide,
+          order: index,
+        }),
+      );
       onReorder(reordered);
     }
   };
@@ -159,8 +177,15 @@ export function SlideList({
             <p className="text-sm mt-1">Click "Add Slide" to start</p>
           </div>
         ) : (
-          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-            <SortableContext items={slides.map((s) => s.tempId)} strategy={verticalListSortingStrategy}>
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={slides.map((s) => s.tempId)}
+              strategy={verticalListSortingStrategy}
+            >
               {slides.map((slide, index) => (
                 <SortableSlideItem
                   key={slide.tempId}

--- a/Frontend/EduLiteFrontend/src/components/slideshow/editor/SlidePreview.tsx
+++ b/Frontend/EduLiteFrontend/src/components/slideshow/editor/SlidePreview.tsx
@@ -373,6 +373,15 @@ export function SlidePreview({
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [isExpanded, isVisible, onPrev, onNext]);
 
+  // Lock body scroll when expanded
+  useEffect(() => {
+    if (!isExpanded) return;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isExpanded]);
+
   if (!isVisible || !slide) {
     return null;
   }
@@ -444,21 +453,31 @@ export function SlidePreview({
 
       {/* Expanded fullscreen preview */}
       {isExpanded && (
-        <div className="fixed inset-0 z-50 bg-black flex justify-center overflow-auto py-8">
+        <div
+          className={`fixed inset-0 z-50 flex justify-center overflow-auto py-8 ${isDarkMode ? "bg-black" : "bg-white"}`}
+        >
           {/* Floating hint and slide counter */}
-          <div className="fixed top-4 left-4 flex items-center gap-4 text-white/60 text-sm z-10">
+          <div
+            className={`fixed top-4 left-4 flex items-center gap-4 text-sm z-10 ${isDarkMode ? "text-white/60" : "text-gray-500"}`}
+          >
             <span>
               Press{" "}
-              <kbd className="px-2 py-0.5 bg-white/10 rounded text-white/80">
+              <kbd
+                className={`px-2 py-0.5 rounded ${isDarkMode ? "bg-white/10 text-white/80" : "bg-gray-200 text-gray-700"}`}
+              >
                 Esc
               </kbd>{" "}
               or{" "}
-              <kbd className="px-2 py-0.5 bg-white/10 rounded text-white/80">
+              <kbd
+                className={`px-2 py-0.5 rounded ${isDarkMode ? "bg-white/10 text-white/80" : "bg-gray-200 text-gray-700"}`}
+              >
                 E
               </kbd>{" "}
               to close
             </span>
-            <span className="text-white/80 font-medium">
+            <span
+              className={`font-medium ${isDarkMode ? "text-white/80" : "text-gray-700"}`}
+            >
               {currentIndex + 1} / {totalSlides}
             </span>
           </div>
@@ -466,23 +485,29 @@ export function SlidePreview({
           {/* Close button */}
           <button
             onClick={() => setIsExpanded(false)}
-            className="fixed top-4 right-4 p-2 rounded-lg hover:bg-white/10 transition-colors cursor-pointer z-10"
+            className={`fixed top-4 right-4 p-2 rounded-lg transition-colors cursor-pointer z-10 ${isDarkMode ? "hover:bg-white/10" : "hover:bg-gray-200"}`}
             title="Close (Esc/E)"
           >
-            <HiXMark className="w-6 h-6 text-white" />
+            <HiXMark
+              className={`w-6 h-6 ${isDarkMode ? "text-white" : "text-gray-700"}`}
+            />
           </button>
 
           {/* Full presentation-style slide display */}
           <div className="w-full max-w-6xl px-16 my-auto text-center slide-text-lg">
-            <div className="text-white slide-content prose-headings:text-white prose-p:text-white prose-li:text-white">
+            <div
+              className={`slide-content ${isDarkMode ? "text-white prose-headings:text-white prose-p:text-white prose-li:text-white" : "text-gray-900 prose-headings:text-gray-900 prose-p:text-gray-900 prose-li:text-gray-900"}`}
+            >
               {renderedContent ? (
                 <SlideContentWithCodeBlocks
                   processedHtml={processedHtml}
                   codeBlocks={codeBlocks}
-                  isDarkMode={true}
+                  isDarkMode={isDarkMode}
                 />
               ) : (
-                <div className="text-center py-12 text-gray-400">
+                <div
+                  className={`text-center py-12 ${isDarkMode ? "text-gray-400" : "text-gray-500"}`}
+                >
                   <p className="text-lg">No content to preview</p>
                 </div>
               )}
@@ -491,11 +516,18 @@ export function SlidePreview({
 
           {/* Navigation Arrows */}
           {onPrev && (
-            <div className="fixed left-4 top-1/2 -translate-y-1/2">
+            <div className="fixed left-4 top-1/2 -translate-y-1/2 pointer-events-none z-10">
               <button
                 onClick={onPrev}
+                onWheel={(e) => {
+                  const expandedContainer = e.currentTarget.closest(
+                    '[class*="overflow-auto"]',
+                  );
+                  if (expandedContainer)
+                    expandedContainer.scrollTop += e.deltaY;
+                }}
                 disabled={currentIndex === 0}
-                className="p-4 rounded-full bg-white/10 hover:bg-white/20 backdrop-blur-lg text-white transition-all disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"
+                className={`p-4 rounded-full backdrop-blur-lg transition-all disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer shadow-lg pointer-events-auto ${isDarkMode ? "bg-gray-800/90 hover:bg-gray-700 text-gray-100 hover:text-white" : "bg-white/90 hover:bg-white text-gray-900"}`}
                 aria-label="Previous slide"
                 title="Previous slide (←)"
               >
@@ -505,11 +537,18 @@ export function SlidePreview({
           )}
 
           {onNext && (
-            <div className="fixed right-4 top-1/2 -translate-y-1/2">
+            <div className="fixed right-4 top-1/2 -translate-y-1/2 pointer-events-none z-10">
               <button
                 onClick={onNext}
+                onWheel={(e) => {
+                  const expandedContainer = e.currentTarget.closest(
+                    '[class*="overflow-auto"]',
+                  );
+                  if (expandedContainer)
+                    expandedContainer.scrollTop += e.deltaY;
+                }}
                 disabled={currentIndex === totalSlides - 1}
-                className="p-4 rounded-full bg-white/10 hover:bg-white/20 backdrop-blur-lg text-white transition-all disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"
+                className={`p-4 rounded-full backdrop-blur-lg transition-all disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer shadow-lg pointer-events-auto ${isDarkMode ? "bg-gray-800/90 hover:bg-gray-700 text-gray-100 hover:text-white" : "bg-white/90 hover:bg-white text-gray-900"}`}
                 aria-label="Next slide"
                 title="Next slide (→)"
               >

--- a/Frontend/EduLiteFrontend/src/index.css
+++ b/Frontend/EduLiteFrontend/src/index.css
@@ -1,112 +1,112 @@
- @import "tailwindcss";
- @custom-variant dark (&:where(.dark, .dark *));
+@import "tailwindcss";
+@custom-variant dark (&:where(.dark, .dark *));
 
 /* Context Menu Animation */
 @keyframes scale-fade {
-  from {
-    opacity: 0;
-    transform: scale(0.95);
-  }
-  to {
-    opacity: 1;
-    transform: scale(1);
-  }
+    from {
+        opacity: 0;
+        transform: scale(0.95);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1);
+    }
 }
 
 .animate-scale-fade {
-  animation: scale-fade 0.15s ease-out;
+    animation: scale-fade 0.15s ease-out;
 }
 
 /* ========== Slideshow Content Auto-Scaling ========== */
 /* Very short content (< 100 chars) - Large and impactful */
 .slide-text-xl .slide-title {
-  font-size: 4rem; /* 64px */
-  line-height: 1.2;
-  margin-bottom: 2rem;
+    font-size: 4rem; /* 64px */
+    line-height: 1.2;
+    margin-bottom: 2rem;
 }
 
 .slide-text-xl .slide-content {
-  font-size: 2.5rem; /* 40px */
-  line-height: 1.6;
+    font-size: 2.5rem; /* 40px */
+    line-height: 1.6;
 }
 
 /* Short content (100-300 chars) - Comfortable reading */
 .slide-text-lg .slide-title {
-  font-size: 3.5rem; /* 56px */
-  line-height: 1.2;
-  margin-bottom: 1.5rem;
+    font-size: 3.5rem; /* 56px */
+    line-height: 1.2;
+    margin-bottom: 1.5rem;
 }
 
 .slide-text-lg .slide-content {
-  font-size: 2rem; /* 32px */
-  line-height: 1.7;
+    font-size: 2rem; /* 32px */
+    line-height: 1.7;
 }
 
 /* Medium content (300-600 chars) - Balanced */
 .slide-text-md .slide-title {
-  font-size: 2.5rem; /* 40px */
-  line-height: 1.3;
-  margin-bottom: 1.25rem;
+    font-size: 2.5rem; /* 40px */
+    line-height: 1.3;
+    margin-bottom: 1.25rem;
 }
 
 .slide-text-md .slide-content {
-  font-size: 1.5rem; /* 24px */
-  line-height: 1.7;
+    font-size: 1.5rem; /* 24px */
+    line-height: 1.7;
 }
 
 /* Long content (600-1000 chars) - Compact but readable */
 .slide-text-sm .slide-title {
-  font-size: 2rem; /* 32px */
-  line-height: 1.3;
-  margin-bottom: 1rem;
+    font-size: 2rem; /* 32px */
+    line-height: 1.3;
+    margin-bottom: 1rem;
 }
 
 .slide-text-sm .slide-content {
-  font-size: 1.25rem; /* 20px */
-  line-height: 1.75;
+    font-size: 1.25rem; /* 20px */
+    line-height: 1.75;
 }
 
 /* Very long content (> 1000 chars) - Maximum density */
 .slide-text-xs .slide-title {
-  font-size: 1.75rem; /* 28px */
-  line-height: 1.3;
-  margin-bottom: 0.75rem;
+    font-size: 1.75rem; /* 28px */
+    line-height: 1.3;
+    margin-bottom: 0.75rem;
 }
 
 .slide-text-xs .slide-content {
-  font-size: 1.1rem; /* 17.6px */
-  line-height: 1.8;
+    font-size: 1.1rem; /* 17.6px */
+    line-height: 1.8;
 }
 
 /* Scale alert/callout/card content too */
 .slide-text-xl .sb-alert,
 .slide-text-xl .sb-callout,
 .slide-text-xl .sb-card {
-  font-size: 2.25rem;
+    font-size: 2.25rem;
 }
 
 .slide-text-lg .sb-alert,
 .slide-text-lg .sb-callout,
 .slide-text-lg .sb-card {
-  font-size: 1.75rem;
+    font-size: 1.75rem;
 }
 
 .slide-text-md .sb-alert,
 .slide-text-md .sb-callout,
 .slide-text-md .sb-card {
-  font-size: 1.35rem;
+    font-size: 1.35rem;
 }
 
 .slide-text-sm .sb-alert,
 .slide-text-sm .sb-callout,
 .slide-text-sm .sb-card {
-  font-size: 1.15rem;
+    font-size: 1.15rem;
 }
 
 .slide-text-xs .sb-alert,
 .slide-text-xs .sb-callout,
 .slide-text-xs .sb-card {
-  font-size: 1rem;
+    font-size: 1rem;
 }
 
 /* Ensure nested elements inherit and scale properly */
@@ -114,176 +114,186 @@
 .slide-content ul,
 .slide-content ol,
 .slide-content blockquote {
-  margin-top: 0.5em;
-  margin-bottom: 0.5em;
+    margin-top: 0.5em;
+    margin-bottom: 0.5em;
 }
 
 /* Heading sizes - Scale based on level */
 .slide-content h1 {
-  font-size: 1.8em;
-  font-weight: 700;
-  margin-top: 0.75em;
-  margin-bottom: 0.5em;
+    font-size: 1.8em;
+    font-weight: 700;
+    margin-top: 0.75em;
+    margin-bottom: 0.5em;
 }
 
 .slide-content h2 {
-  font-size: 1.5em;
-  font-weight: 600;
-  margin-top: 0.75em;
-  margin-bottom: 0.5em;
+    font-size: 1.5em;
+    font-weight: 600;
+    margin-top: 0.75em;
+    margin-bottom: 0.5em;
 }
 
 .slide-content h3 {
-  font-size: 1.25em;
-  font-weight: 600;
-  margin-top: 0.75em;
-  margin-bottom: 0.5em;
+    font-size: 1.25em;
+    font-weight: 600;
+    margin-top: 0.75em;
+    margin-bottom: 0.5em;
 }
 
 .slide-content h4 {
-  font-size: 1.1em;
-  font-weight: 600;
-  margin-top: 0.75em;
-  margin-bottom: 0.5em;
+    font-size: 1.1em;
+    font-weight: 600;
+    margin-top: 0.75em;
+    margin-bottom: 0.5em;
 }
 
 .slide-content h5,
 .slide-content h6 {
-  font-size: 1em;
-  font-weight: 600;
-  margin-top: 0.75em;
-  margin-bottom: 0.5em;
+    font-size: 1em;
+    font-weight: 600;
+    margin-top: 0.75em;
+    margin-bottom: 0.5em;
 }
 
 .slide-content ul,
 .slide-content ol {
-  text-align: left;
-  display: block;
-  list-style-position: outside;
-  margin: 1em auto;
-  max-width: fit-content;
+    text-align: left;
+    display: block;
+    list-style-position: outside;
+    margin: 1em auto;
+    max-width: fit-content;
 }
 
 .slide-content ul {
-  list-style-type: disc;
-  padding-left: 2em;
+    list-style-type: disc;
+    padding-left: 2em;
 }
 
 .slide-content ol {
-  list-style-type: decimal;
-  padding-left: -4.4em;
+    list-style-type: decimal;
+    padding-left: 2em;
 }
 
 .slide-content li {
-  margin: 0.5em 0;
-  text-align: left;
+    margin: 0.5em 0;
+    text-align: left;
 }
 
 /* ========== Slide Scrollbar Styling ========== */
 /* Custom scrollbar for overflowing slides - Made more prominent and obvious */
 .overflow-y-auto::-webkit-scrollbar {
-  width: 14px !important;
+    width: 14px !important;
 }
 
 .overflow-y-auto::-webkit-scrollbar-track {
-  background: #e5e7eb !important;
-  border-radius: 8px !important;
+    background: #e5e7eb !important;
+    border-radius: 8px !important;
 }
 
 .dark .overflow-y-auto::-webkit-scrollbar-track {
-  background: #374151 !important;
+    background: #374151 !important;
 }
 
 .overflow-y-auto::-webkit-scrollbar-thumb {
-  background: #60a5fa !important;
-  border-radius: 8px !important;
-  border: 2px solid #e5e7eb !important;
+    background: #60a5fa !important;
+    border-radius: 8px !important;
+    border: 2px solid #e5e7eb !important;
 }
 
 .dark .overflow-y-auto::-webkit-scrollbar-thumb {
-  background: #2563eb !important;
-  border: 2px solid #374151 !important;
+    background: #2563eb !important;
+    border: 2px solid #374151 !important;
 }
 
 .overflow-y-auto::-webkit-scrollbar-thumb:hover {
-  background: #3b82f6 !important;
+    background: #3b82f6 !important;
 }
 
 .dark .overflow-y-auto::-webkit-scrollbar-thumb:hover {
-  background: #1d4ed8 !important;
+    background: #1d4ed8 !important;
 }
 
 /* Firefox scrollbar - More prominent */
 .overflow-y-auto {
-  scrollbar-width: auto; /* Use auto instead of thin for better visibility */
-  scrollbar-color: rgba(59, 130, 246, 0.7) rgba(0, 0, 0, 0.1); /* Blue thumb, gray track */
+    scrollbar-width: auto; /* Use auto instead of thin for better visibility */
+    scrollbar-color: rgba(59, 130, 246, 0.7) rgba(0, 0, 0, 0.1); /* Blue thumb, gray track */
 }
 
 .dark .overflow-y-auto {
-  scrollbar-color: rgba(96, 165, 250, 0.7) rgba(255, 255, 255, 0.1);
+    scrollbar-color: rgba(96, 165, 250, 0.7) rgba(255, 255, 255, 0.1);
 }
 
 /* ========== Slide Image Styling ========== */
 /* Make images in slides look good and load smoothly */
 .slide-content img {
-  max-width: 100%;
-  height: auto;
-  margin: 1.5em auto;
-  display: block;
-  border-radius: 0.75rem;
-  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
-  /* Smooth loading */
-  background-color: #f3f4f6;
-  min-height: 200px; /* Prevent layout shift while loading */
-  object-fit: cover;
-  transition: opacity 0.3s ease-in-out, transform 0.3s ease-in-out;
+    max-width: 100%;
+    height: auto;
+    margin: 1.5em auto;
+    display: block;
+    border-radius: 0.75rem;
+    box-shadow:
+        0 10px 25px -5px rgba(0, 0, 0, 0.1),
+        0 10px 10px -5px rgba(0, 0, 0, 0.04);
+    /* Smooth loading */
+    background-color: #f3f4f6;
+    min-height: 200px; /* Prevent layout shift while loading */
+    object-fit: cover;
+    transition:
+        opacity 0.3s ease-in-out,
+        transform 0.3s ease-in-out;
 }
 
 .dark .slide-content img {
-  background-color: #374151;
-  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.3), 0 10px 10px -5px rgba(0, 0, 0, 0.2);
+    background-color: #374151;
+    box-shadow:
+        0 10px 25px -5px rgba(0, 0, 0, 0.3),
+        0 10px 10px -5px rgba(0, 0, 0, 0.2);
 }
 
 /* Loading state - slightly transparent while image loads */
 .slide-content img:not([src]),
 .slide-content img[src=""] {
-  opacity: 0.5;
+    opacity: 0.5;
 }
 
 /* Hover effect for images */
 .slide-content img:hover {
-  transform: scale(1.02);
-  box-shadow: 0 20px 35px -5px rgba(0, 0, 0, 0.15), 0 15px 15px -5px rgba(0, 0, 0, 0.06);
+    transform: scale(1.02);
+    box-shadow:
+        0 20px 35px -5px rgba(0, 0, 0, 0.15),
+        0 15px 15px -5px rgba(0, 0, 0, 0.06);
 }
 
 .dark .slide-content img:hover {
-  box-shadow: 0 20px 35px -5px rgba(0, 0, 0, 0.4), 0 15px 15px -5px rgba(0, 0, 0, 0.3);
+    box-shadow:
+        0 20px 35px -5px rgba(0, 0, 0, 0.4),
+        0 15px 15px -5px rgba(0, 0, 0, 0.3);
 }
 
 /* Scale images based on slide text size */
 .slide-text-xl img {
-  max-height: 500px;
-  border-radius: 1rem;
+    max-height: 500px;
+    border-radius: 1rem;
 }
 
 .slide-text-lg img {
-  max-height: 450px;
-  border-radius: 0.875rem;
+    max-height: 450px;
+    border-radius: 0.875rem;
 }
 
 .slide-text-md img {
-  max-height: 400px;
-  border-radius: 0.75rem;
+    max-height: 400px;
+    border-radius: 0.75rem;
 }
 
 .slide-text-sm img {
-  max-height: 350px;
-  border-radius: 0.625rem;
+    max-height: 350px;
+    border-radius: 0.625rem;
 }
 
 .slide-text-xs img {
-  max-height: 300px;
-  border-radius: 0.5rem;
+    max-height: 300px;
+    border-radius: 0.5rem;
 }
 
 /* ========== Preview Panel Scaled Classes ========== */
@@ -291,136 +301,216 @@
 
 /* Preview text scaling - 40% of presentation size */
 .preview-text-xl .slide-content {
-  font-size: 1rem; /* 40% of 2.5rem */
-  line-height: 1.6;
+    font-size: 1rem; /* 40% of 2.5rem */
+    line-height: 1.6;
 }
 
 .preview-text-lg .slide-content {
-  font-size: 0.8rem; /* 40% of 2rem */
-  line-height: 1.7;
+    font-size: 0.8rem; /* 40% of 2rem */
+    line-height: 1.7;
 }
 
 .preview-text-md .slide-content {
-  font-size: 0.6rem; /* 40% of 1.5rem */
-  line-height: 1.7;
+    font-size: 0.6rem; /* 40% of 1.5rem */
+    line-height: 1.7;
 }
 
 .preview-text-sm .slide-content {
-  font-size: 0.5rem; /* 40% of 1.25rem */
-  line-height: 1.7;
+    font-size: 0.5rem; /* 40% of 1.25rem */
+    line-height: 1.7;
 }
 
 .preview-text-xs .slide-content {
-  font-size: 0.44rem; /* 40% of 1.1rem */
-  line-height: 1.7;
+    font-size: 0.44rem; /* 40% of 1.1rem */
+    line-height: 1.7;
 }
 
 /* Preview title scaling */
 .preview-text-xl .slide-title {
-  font-size: 1.6rem;
-  line-height: 1.2;
-  margin-bottom: 0.8rem;
+    font-size: 1.6rem;
+    line-height: 1.2;
+    margin-bottom: 0.8rem;
 }
 
 .preview-text-lg .slide-title {
-  font-size: 1.4rem;
-  line-height: 1.2;
-  margin-bottom: 0.6rem;
+    font-size: 1.4rem;
+    line-height: 1.2;
+    margin-bottom: 0.6rem;
 }
 
 .preview-text-md .slide-title {
-  font-size: 1rem;
-  line-height: 1.3;
-  margin-bottom: 0.5rem;
+    font-size: 1rem;
+    line-height: 1.3;
+    margin-bottom: 0.5rem;
 }
 
 .preview-text-sm .slide-title {
-  font-size: 0.875rem;
-  line-height: 1.3;
-  margin-bottom: 0.4rem;
+    font-size: 0.875rem;
+    line-height: 1.3;
+    margin-bottom: 0.4rem;
 }
 
 .preview-text-xs .slide-title {
-  font-size: 0.75rem;
-  line-height: 1.4;
-  margin-bottom: 0.3rem;
+    font-size: 0.75rem;
+    line-height: 1.4;
+    margin-bottom: 0.3rem;
 }
 
 /* Preview image scaling */
 .preview-text-xl img {
-  max-height: 200px;
+    max-height: 200px;
 }
 
 .preview-text-lg img {
-  max-height: 180px;
+    max-height: 180px;
 }
 
 .preview-text-md img {
-  max-height: 160px;
+    max-height: 160px;
 }
 
 .preview-text-sm img {
-  max-height: 140px;
+    max-height: 140px;
 }
 
 .preview-text-xs img {
-  max-height: 120px;
+    max-height: 120px;
 }
 
 /* ========== Preview Heading Styles ========== */
 /* Make headings in preview actually look like headings */
-.preview-text-xl h1, .preview-text-xl .slide-title {
-  font-size: 2rem !important;
-  font-weight: 700;
-  line-height: 1.2;
-  margin-bottom: 1rem;
+.preview-text-xl h1,
+.preview-text-xl .slide-title {
+    font-size: 2rem !important;
+    font-weight: 700;
+    line-height: 1.2;
+    margin-bottom: 1rem;
 }
 
-.preview-text-lg h1, .preview-text-lg .slide-title {
-  font-size: 1.75rem !important;
-  font-weight: 700;
-  line-height: 1.2;
-  margin-bottom: 0.875rem;
+.preview-text-lg h1,
+.preview-text-lg .slide-title {
+    font-size: 1.75rem !important;
+    font-weight: 700;
+    line-height: 1.2;
+    margin-bottom: 0.875rem;
 }
 
-.preview-text-md h1, .preview-text-md .slide-title {
-  font-size: 1.5rem !important;
-  font-weight: 700;
-  line-height: 1.2;
-  margin-bottom: 0.75rem;
+.preview-text-md h1,
+.preview-text-md .slide-title {
+    font-size: 1.5rem !important;
+    font-weight: 700;
+    line-height: 1.2;
+    margin-bottom: 0.75rem;
 }
 
-.preview-text-sm h1, .preview-text-sm .slide-title {
-  font-size: 1.25rem !important;
-  font-weight: 700;
-  line-height: 1.2;
-  margin-bottom: 0.625rem;
+.preview-text-sm h1,
+.preview-text-sm .slide-title {
+    font-size: 1.25rem !important;
+    font-weight: 700;
+    line-height: 1.2;
+    margin-bottom: 0.625rem;
 }
 
-.preview-text-xs h1, .preview-text-xs .slide-title {
-  font-size: 1.125rem !important;
-  font-weight: 700;
-  line-height: 1.2;
-  margin-bottom: 0.5rem;
+.preview-text-xs h1,
+.preview-text-xs .slide-title {
+    font-size: 1.125rem !important;
+    font-weight: 700;
+    line-height: 1.2;
+    margin-bottom: 0.5rem;
 }
 
 /* H2 in preview */
-.preview-text-xl h2 { font-size: 1.5rem !important; font-weight: 600; margin-top: 1rem; margin-bottom: 0.75rem; }
-.preview-text-lg h2 { font-size: 1.375rem !important; font-weight: 600; margin-top: 0.875rem; margin-bottom: 0.625rem; }
-.preview-text-md h2 { font-size: 1.25rem !important; font-weight: 600; margin-top: 0.75rem; margin-bottom: 0.5rem; }
-.preview-text-sm h2 { font-size: 1.125rem !important; font-weight: 600; margin-top: 0.625rem; margin-bottom: 0.5rem; }
-.preview-text-xs h2 { font-size: 1rem !important; font-weight: 600; margin-top: 0.5rem; margin-bottom: 0.375rem; }
+.preview-text-xl h2 {
+    font-size: 1.5rem !important;
+    font-weight: 600;
+    margin-top: 1rem;
+    margin-bottom: 0.75rem;
+}
+.preview-text-lg h2 {
+    font-size: 1.375rem !important;
+    font-weight: 600;
+    margin-top: 0.875rem;
+    margin-bottom: 0.625rem;
+}
+.preview-text-md h2 {
+    font-size: 1.25rem !important;
+    font-weight: 600;
+    margin-top: 0.75rem;
+    margin-bottom: 0.5rem;
+}
+.preview-text-sm h2 {
+    font-size: 1.125rem !important;
+    font-weight: 600;
+    margin-top: 0.625rem;
+    margin-bottom: 0.5rem;
+}
+.preview-text-xs h2 {
+    font-size: 1rem !important;
+    font-weight: 600;
+    margin-top: 0.5rem;
+    margin-bottom: 0.375rem;
+}
 
 /* H3 in preview */
-.preview-text-xl h3 { font-size: 1.25rem !important; font-weight: 600; margin-top: 0.75rem; margin-bottom: 0.5rem; }
-.preview-text-lg h3 { font-size: 1.125rem !important; font-weight: 600; margin-top: 0.625rem; margin-bottom: 0.5rem; }
-.preview-text-md h3 { font-size: 1rem !important; font-weight: 600; margin-top: 0.5rem; margin-bottom: 0.375rem; }
-.preview-text-sm h3 { font-size: 0.875rem !important; font-weight: 600; margin-top: 0.5rem; margin-bottom: 0.375rem; }
-.preview-text-xs h3 { font-size: 0.75rem !important; font-weight: 600; margin-top: 0.375rem; margin-bottom: 0.25rem; }
+.preview-text-xl h3 {
+    font-size: 1.25rem !important;
+    font-weight: 600;
+    margin-top: 0.75rem;
+    margin-bottom: 0.5rem;
+}
+.preview-text-lg h3 {
+    font-size: 1.125rem !important;
+    font-weight: 600;
+    margin-top: 0.625rem;
+    margin-bottom: 0.5rem;
+}
+.preview-text-md h3 {
+    font-size: 1rem !important;
+    font-weight: 600;
+    margin-top: 0.5rem;
+    margin-bottom: 0.375rem;
+}
+.preview-text-sm h3 {
+    font-size: 0.875rem !important;
+    font-weight: 600;
+    margin-top: 0.5rem;
+    margin-bottom: 0.375rem;
+}
+.preview-text-xs h3 {
+    font-size: 0.75rem !important;
+    font-weight: 600;
+    margin-top: 0.375rem;
+    margin-bottom: 0.25rem;
+}
 
 /* Regular text in preview */
-.preview-text-xl p, .preview-text-xl li { font-size: 1rem !important; line-height: 1.6; margin-bottom: 0.75rem; }
-.preview-text-lg p, .preview-text-lg li { font-size: 0.875rem !important; line-height: 1.6; margin-bottom: 0.625rem; }
-.preview-text-md p, .preview-text-md li { font-size: 0.75rem !important; line-height: 1.6; margin-bottom: 0.5rem; }
-.preview-text-sm p, .preview-text-sm li { font-size: 0.625rem !important; line-height: 1.6; margin-bottom: 0.375rem; }
-.preview-text-xs p, .preview-text-xs li { font-size: 0.5625rem !important; line-height: 1.6; margin-bottom: 0.25rem; }
+.preview-text-xl p,
+.preview-text-xl li {
+    font-size: 1rem !important;
+    line-height: 1.6;
+    margin-bottom: 0.75rem;
+}
+.preview-text-lg p,
+.preview-text-lg li {
+    font-size: 0.875rem !important;
+    line-height: 1.6;
+    margin-bottom: 0.625rem;
+}
+.preview-text-md p,
+.preview-text-md li {
+    font-size: 0.75rem !important;
+    line-height: 1.6;
+    margin-bottom: 0.5rem;
+}
+.preview-text-sm p,
+.preview-text-sm li {
+    font-size: 0.625rem !important;
+    line-height: 1.6;
+    margin-bottom: 0.375rem;
+}
+.preview-text-xs p,
+.preview-text-xs li {
+    font-size: 0.5625rem !important;
+    line-height: 1.6;
+    margin-bottom: 0.25rem;
+}

--- a/Frontend/EduLiteFrontend/src/pages/SlideshowEditorPage.tsx
+++ b/Frontend/EduLiteFrontend/src/pages/SlideshowEditorPage.tsx
@@ -284,10 +284,8 @@ export default function SlideshowEditorPage() {
         // Update slides with the backend response to get proper IDs and rendered_content
         const updatedSlides: EditorSlide[] = updated.slides.map(
           (slide, index) => {
-            // Try to preserve the tempId by matching content
-            const existingSlide = validSlides.find(
-              (s) => s.content === ("content" in slide ? slide.content : ""),
-            );
+            // Preserve tempId by matching position (order is preserved through save)
+            const existingSlide = validSlides[index];
             return {
               id: slide.id,
               tempId: existingSlide?.tempId || crypto.randomUUID(),

--- a/Makefile
+++ b/Makefile
@@ -147,10 +147,12 @@ build:  ## Build all Docker images
 	@echo "$(CYAN)Building Docker images...$(NC)"
 	cd $(DOCKER_DIR) && $(DOCKER_COMPOSE) build
 
-rebuild:  ## Rebuild all images from scratch (no cache)
+rebuild:  ## Rebuild all images from scratch (no cache) and restart services
 	@echo "$(CYAN)Rebuilding all images from scratch...$(NC)"
 	cd $(DOCKER_DIR) && $(DOCKER_COMPOSE) build --no-cache
-	@echo "$(GREEN)✓ Images rebuilt$(NC)"
+	@echo "$(CYAN)Restarting services with new images...$(NC)"
+	cd $(DOCKER_DIR) && $(DOCKER_COMPOSE) down && $(DOCKER_COMPOSE) up -d
+	@echo "$(GREEN)✓ Images rebuilt and services restarted$(NC)"
 
 clean:  ## Stop and remove containers, networks, volumes (WARNING: Deletes data!)
 	@echo "$(RED)⚠️  WARNING: This will delete ALL containers, networks, and volumes!$(NC)"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,7 +17,7 @@ daphne==4.2.1
 Django==5.2.1
 django-cors-headers==4.7.0
 django-mercury-performance==0.1.3b6
-django-spellbook==0.2.5b2
+django-spellbook==0.2.5b14
 djangorestframework==3.16.0
 djangorestframework_simplejwt==5.5.0
 drf-spectacular==0.28.0


### PR DESCRIPTION
# Spellblocks Toolbar Dropdown + Slideshow Bug Fixes

## Summary
Adds spellblock insertion toolbar dropdown to the slide editor and fixes multiple bugs across the slideshow editor and presentation viewer.

## Changes

### New Feature: Spellblocks Toolbar Dropdown
- Added dropdown menu to EditorToolbar with Card and Accordion spellblock insertion
- Click-outside and Escape key to close dropdown

### Bug Fixes

**Expanded preview forced dark mode**
- Expanded preview was hardcoded to `bg-black` and `isDarkMode={true}` regardless of user theme
- Now respects the actual light/dark mode setting across all elements (background, text, nav arrows, close button, kbd hints)

**Duplicate slide caused shared selection**
- After saving, `tempId` was preserved by matching slides on `content` using `.find()` — duplicated slides with identical content all got the same `tempId`
- Fixed to match by index position instead, since slide order is preserved through save

**Duplicate/delete button interactions with drag-and-drop**
- `PointerSensor` had no activation distance, causing clicks on duplicate/delete buttons to trigger drag events
- Added `distance: 8` activation constraint so clicks work cleanly
- Added `cursor-pointer` to duplicate and delete buttons

**Ordered lists not rendering**
- Updated `django-spellbook` from `0.2.5b2` to `0.2.5b14` which fixes ordered list parsing
- Fixed `padding-left: -4.4em` (invalid CSS) on `.slide-content ol` to `padding-left: 2em`

**Presentation view nav arrows block scrolling**
- Added `pointer-events-none` on arrow wrappers with `pointer-events-auto` on buttons
- Added `onWheel` handlers to forward scroll events to the slide scroll container

**Expanded preview scroll leaks to page body**
- Scrolling past content in expanded preview would scroll the page underneath
- Added `body` scroll lock when expanded preview is open

### Makefile
- `make rebuild` now automatically runs `down` + `up -d` after building so new images are actually used

## Files Changed
- `Frontend/.../editor/EditorToolbar.tsx` — spellblocks dropdown
- `Frontend/.../editor/SlideEditor.tsx` — toolbar integration
- `Frontend/.../editor/SlideList.tsx` — drag sensor fix, cursor-pointer
- `Frontend/.../editor/SlidePreview.tsx` — dark mode fix, scroll fixes, nav arrow consistency
- `Frontend/.../SlideshowViewer.tsx` — nav arrow scroll passthrough
- `Frontend/.../src/index.css` — ol padding fix, preview scaling
- `Frontend/.../pages/SlideshowEditorPage.tsx` — duplicate tempId fix
- `backend/requirements.txt` — django-spellbook version bump
- `Makefile` — rebuild now restarts services
