### PR TITLE
fix drag on edit

### DIFF
--- a/Frontend/EduLiteFrontend/src/components/slideshow/editor/SlideList.tsx
+++ b/Frontend/EduLiteFrontend/src/components/slideshow/editor/SlideList.tsx
@@ -67,18 +67,16 @@ function SortableSlideItem({
   return (
     <div ref={setNodeRef} style={style} className={`group relative`}>
       <div
-        className={`flex items-start gap-2 p-3 border rounded-lg cursor-pointer transition-all ${
+        {...attributes}
+        {...listeners}
+        className={`flex items-start gap-2 p-3 border rounded-lg cursor-pointer active:cursor-grabbing transition-all select-none ${
           isSelected
             ? "bg-blue-50 dark:bg-blue-900/20 border-blue-500"
             : "bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600"
         }`}
         onClick={onSelect}
       >
-        <div
-          {...attributes}
-          {...listeners}
-          className="cursor-grab active:cursor-grabbing pt-1"
-        >
+        <div className="pt-1">
           <HiMenu className="w-4 h-4 text-gray-400" />
         </div>
 


### PR DESCRIPTION
# Fix: Slide List Cards - Text Selection Interferes with Click/Drag (#212)

## Problem
Text in slide list cards was selectable, and drag-and-drop only worked from the small drag handle icon — not the entire card.

## Changes

### `Frontend/.../editor/SlideList.tsx`
- Added `select-none` to card container to prevent text highlighting
- Moved drag listeners (`attributes`, `listeners`) from the handle icon to the entire card div
- Handle icon remains as a visual indicator only
- `active:cursor-grabbing` on the card for drag feedback

## How It Works
The `PointerSensor` has a `distance: 8` activation constraint (added in a prior fix), so regular clicks still select the slide without triggering a drag. Dragging activates after 8px of movement from anywhere on the card.

## Acceptance Criteria
- Text in slide cards is not highlightable
- Clicking anywhere on card selects the slide
- Drag and drop works from anywhere on the card
