### PR TITLE
slideshows in profile

### DIFF
--- a/Frontend/EduLiteFrontend/src/pages/ProfilePage.tsx
+++ b/Frontend/EduLiteFrontend/src/pages/ProfilePage.tsx
@@ -1,6 +1,20 @@
 import React, { useState, useEffect, useRef, ChangeEvent } from "react";
 import { useNavigate, useBlocker } from "react-router-dom";
-import { FaUser, FaCamera, FaSignOutAlt, FaSave, FaUserFriends, FaCog, FaStickyNote, FaComments, FaGraduationCap, FaChevronDown, FaChevronUp, FaTrash } from "react-icons/fa";
+import {
+  FaUser,
+  FaCamera,
+  FaSignOutAlt,
+  FaSave,
+  FaUserFriends,
+  FaCog,
+  FaStickyNote,
+  FaComments,
+  FaGraduationCap,
+  FaChevronDown,
+  FaChevronUp,
+  FaTrash,
+  FaFilm,
+} from "react-icons/fa";
 import toast from "react-hot-toast";
 import { useAuth } from "../hooks/useAuth";
 import ConfirmationModal from "../components/common/ConfirmationModal";
@@ -9,7 +23,10 @@ import LazySelect from "../components/common/LazySelect";
 import UnsavedChangesModal from "../components/common/UnsavedChangesModal";
 import DeleteAccountModal from "../components/DeleteAccountModal";
 import PrivacySettings from "../components/PrivacySettings";
-import { useUnsavedChanges, useFormDirtyState } from "../hooks/useUnsavedChanges";
+import {
+  useUnsavedChanges,
+  useFormDirtyState,
+} from "../hooks/useUnsavedChanges";
 import { choicesService } from "../services/choicesService";
 import {
   getUserInfo,
@@ -19,23 +36,38 @@ import {
   deleteUserAccount,
   type User,
   type UserProfile,
-  type ProfileUpdateRequest
+  type ProfileUpdateRequest,
 } from "../services/profileApi";
+import {
+  listMySlideshows,
+  type SlideshowListItem,
+} from "../services/slideshowApi";
 
 const ProfilePage: React.FC = () => {
   // State management following existing patterns from LoginPage/SignupPage
   const [userInfo, setUserInfo] = useState<User | null>(null);
   const [profileData, setProfileData] = useState<UserProfile | null>(null);
-  const [originalFormData, setOriginalFormData] = useState<ProfileUpdateRequest>({});
+  const [originalFormData, setOriginalFormData] =
+    useState<ProfileUpdateRequest>({});
   const [formData, setFormData] = useState<ProfileUpdateRequest>({});
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [uploading, setUploading] = useState(false);
-  const [activeTab, setActiveTab] = useState<'friends' | 'notes' | 'chats' | 'courses' | 'settings'>(() => {
+  const [activeTab, setActiveTab] = useState<
+    "friends" | "notes" | "chats" | "courses" | "slideshows" | "settings"
+  >(() => {
     // Load saved tab from localStorage or default to 'friends'
-    const savedTab = localStorage.getItem('profileActiveTab');
-    return (savedTab as 'friends' | 'notes' | 'chats' | 'courses' | 'settings') || 'friends';
+    const savedTab = localStorage.getItem("profileActiveTab");
+    return (
+      (savedTab as
+        | "friends"
+        | "notes"
+        | "chats"
+        | "courses"
+        | "slideshows"
+        | "settings") || "friends"
+    );
   });
   const [showNavigationModal, setShowNavigationModal] = useState(false);
   const [touchedFields, setTouchedFields] = useState<Set<string>>(new Set());
@@ -44,6 +76,9 @@ const ProfilePage: React.FC = () => {
   const [deleting, setDeleting] = useState(false);
   const [showLogoutModal, setShowLogoutModal] = useState(false);
   const [showUnsavedLogoutModal, setShowUnsavedLogoutModal] = useState(false);
+  const [slideshows, setSlideshows] = useState<SlideshowListItem[]>([]);
+  const [slideshowsLoading, setSlideshowsLoading] = useState(false);
+  const slideshowsFetched = useRef(false);
 
   // Refs for file upload
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -62,7 +97,7 @@ const ProfilePage: React.FC = () => {
   // Block navigation when there are unsaved changes
   const blocker = useBlocker(
     ({ currentLocation, nextLocation }) =>
-      isDirty && currentLocation.pathname !== nextLocation.pathname
+      isDirty && currentLocation.pathname !== nextLocation.pathname,
   );
 
   // Store blocker reference for modal callbacks
@@ -70,7 +105,7 @@ const ProfilePage: React.FC = () => {
 
   // Handle blocked navigation with custom modal
   useEffect(() => {
-    if (blocker.state === 'blocked') {
+    if (blocker.state === "blocked") {
       setShowNavigationModal(true);
     }
   }, [blocker]);
@@ -92,7 +127,7 @@ const ProfilePage: React.FC = () => {
 
   // Save active tab to localStorage when it changes
   useEffect(() => {
-    localStorage.setItem('profileActiveTab', activeTab);
+    localStorage.setItem("profileActiveTab", activeTab);
   }, [activeTab]);
 
   // Load user data on component mount
@@ -104,7 +139,7 @@ const ProfilePage: React.FC = () => {
         // Load user info and profile in parallel
         const [userInfoData, profileData] = await Promise.all([
           getUserInfo(),
-          getUserProfile()
+          getUserProfile(),
         ]);
 
         setUserInfo(userInfoData);
@@ -113,14 +148,14 @@ const ProfilePage: React.FC = () => {
         // Initialize form data with current profile values
         // Use defaults for language fields if they're null/empty
         const initialFormData = {
-          first_name: userInfoData.first_name || '',
-          last_name: userInfoData.last_name || '',
-          bio: profileData.bio || '',
-          occupation: profileData.occupation || '',
-          country: profileData.country || '',
-          preferred_language: profileData.preferred_language || 'en',
-          secondary_language: profileData.secondary_language || 'ar',
-          website_url: profileData.website_url || ''
+          first_name: userInfoData.first_name || "",
+          last_name: userInfoData.last_name || "",
+          bio: profileData.bio || "",
+          occupation: profileData.occupation || "",
+          country: profileData.country || "",
+          preferred_language: profileData.preferred_language || "en",
+          secondary_language: profileData.secondary_language || "ar",
+          website_url: profileData.website_url || "",
         };
 
         setFormData(initialFormData);
@@ -142,13 +177,13 @@ const ProfilePage: React.FC = () => {
       try {
         // Load all choices in parallel for instant dropdown access
         await Promise.all([
-          choicesService.getChoices('occupations'),
-          choicesService.getChoices('countries'),
-          choicesService.getChoices('languages')
+          choicesService.getChoices("occupations"),
+          choicesService.getChoices("countries"),
+          choicesService.getChoices("languages"),
         ]);
-        console.log('All choices pre-cached successfully');
+        console.log("All choices pre-cached successfully");
       } catch (error) {
-        console.error('Failed to pre-cache some choices:', error);
+        console.error("Failed to pre-cache some choices:", error);
         // Non-critical error - dropdowns will still work with lazy loading
       }
     };
@@ -156,33 +191,60 @@ const ProfilePage: React.FC = () => {
     cacheAllChoices();
   }, []);
 
+  // Lazy-load slideshows when tab is selected
+  useEffect(() => {
+    if (activeTab !== "slideshows" || slideshowsFetched.current) return;
+    const fetchSlideshows = async () => {
+      setSlideshowsLoading(true);
+      try {
+        const response = await listMySlideshows({ page_size: 10 });
+        setSlideshows(response.results);
+        slideshowsFetched.current = true;
+      } catch (error) {
+        console.error("Failed to load slideshows:", error);
+        toast.error("Failed to load slideshows");
+      } finally {
+        setSlideshowsLoading(false);
+      }
+    };
+    fetchSlideshows();
+  }, [activeTab]);
+
   // Handle field blur to track touched fields
-  const handleBlur = (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement | HTMLButtonElement>) => {
+  const handleBlur = (
+    e: React.FocusEvent<
+      HTMLInputElement | HTMLTextAreaElement | HTMLButtonElement
+    >,
+  ) => {
     const { name } = e.target;
-    setTouchedFields(prev => new Set(prev).add(name));
+    setTouchedFields((prev) => new Set(prev).add(name));
   };
 
   // Handle form field changes (matching SignupPage pattern)
-  const handleChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+  const handleChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+  ) => {
     let { name, value } = e.target;
 
     // Smart website URL handling
-    if (name === 'website_url' && value) {
+    if (name === "website_url" && value) {
       // Block insecure http://
-      if (value.toLowerCase().startsWith('http://')) {
+      if (value.toLowerCase().startsWith("http://")) {
         setErrors((prev) => ({
           ...prev,
-          website_url: "Insecure HTTP not allowed. Please use HTTPS."
+          website_url: "Insecure HTTP not allowed. Please use HTTPS.",
         }));
         return; // Don't update the value
       }
 
       // Auto-add https:// if it looks like a website
       // Check: has a dot, more than 3 chars, and no protocol
-      if (value.includes('.') &&
-          value.length > 3 &&
-          !value.includes('://') &&
-          !value.startsWith('https://')) {
+      if (
+        value.includes(".") &&
+        value.length > 3 &&
+        !value.includes("://") &&
+        !value.startsWith("https://")
+      ) {
         value = `https://${value}`;
       }
     }
@@ -210,18 +272,19 @@ const ProfilePage: React.FC = () => {
       const url = formData.website_url.trim();
 
       // Block http:// for security
-      if (url.toLowerCase().startsWith('http://')) {
+      if (url.toLowerCase().startsWith("http://")) {
         newErrors.website_url = "Insecure HTTP not allowed. Please use HTTPS.";
       } else {
         // Validate URL structure
         try {
           new URL(url);
           // Additional check to ensure it's https
-          if (!url.toLowerCase().startsWith('https://')) {
+          if (!url.toLowerCase().startsWith("https://")) {
             newErrors.website_url = "Please use HTTPS for secure connections";
           }
         } catch {
-          newErrors.website_url = "Please enter a valid URL (e.g., https://example.com)";
+          newErrors.website_url =
+            "Please enter a valid URL (e.g., https://example.com)";
         }
       }
     }
@@ -270,12 +333,13 @@ const ProfilePage: React.FC = () => {
     if (!file) return;
 
     // Validate file type and size
-    if (!['image/jpeg', 'image/png', 'image/webp'].includes(file.type)) {
+    if (!["image/jpeg", "image/png", "image/webp"].includes(file.type)) {
       toast.error("Please select a JPG, PNG, or WEBP image");
       return;
     }
 
-    if (file.size > 5 * 1024 * 1024) { // 5MB limit
+    if (file.size > 5 * 1024 * 1024) {
+      // 5MB limit
       toast.error("Image must be less than 5MB");
       return;
     }
@@ -347,262 +411,275 @@ const ProfilePage: React.FC = () => {
           <div className="lg:col-span-2">
             {/* Glass-morphism container matching LoginPage exactly */}
             <div className="bg-white/80 dark:bg-gray-800/40 backdrop-blur-xl border border-gray-200/50 dark:border-gray-700/30 rounded-3xl shadow-2xl shadow-gray-200/20 dark:shadow-gray-900/20 p-8">
+              {/* Header matching LoginPage typography */}
+              <div className="text-center mb-8">
+                <h2 className="text-3xl font-light text-gray-900 dark:text-white mb-2 tracking-tight">
+                  Your Profile
+                </h2>
+                <p className="text-gray-500 dark:text-gray-400 font-light">
+                  Manage your account information
+                </p>
+              </div>
 
-          {/* Header matching LoginPage typography */}
-          <div className="text-center mb-8">
-            <h2 className="text-3xl font-light text-gray-900 dark:text-white mb-2 tracking-tight">
-              Your Profile
-            </h2>
-            <p className="text-gray-500 dark:text-gray-400 font-light">
-              Manage your account information
-            </p>
-          </div>
+              {/* Profile Picture Section */}
+              <div className="flex flex-col items-center mb-8">
+                <div className="relative">
+                  <div className="w-32 h-32 rounded-full bg-gradient-to-r from-blue-100 to-purple-100 dark:from-blue-900 dark:to-purple-900 flex items-center justify-center overflow-hidden border-4 border-white/50 dark:border-gray-700/50 shadow-xl">
+                    {profileData?.picture ? (
+                      <img
+                        src={profileData.picture}
+                        alt="Profile"
+                        className="w-full h-full object-cover"
+                      />
+                    ) : (
+                      <FaUser className="text-4xl text-gray-400 dark:text-gray-500" />
+                    )}
+                  </div>
 
-          {/* Profile Picture Section */}
-          <div className="flex flex-col items-center mb-8">
-            <div className="relative">
-              <div className="w-32 h-32 rounded-full bg-gradient-to-r from-blue-100 to-purple-100 dark:from-blue-900 dark:to-purple-900 flex items-center justify-center overflow-hidden border-4 border-white/50 dark:border-gray-700/50 shadow-xl">
-                {profileData?.picture ? (
-                  <img
-                    src={profileData.picture}
-                    alt="Profile"
-                    className="w-full h-full object-cover"
+                  {/* Camera upload button */}
+                  <button
+                    onClick={() => fileInputRef.current?.click()}
+                    disabled={uploading}
+                    className="absolute bottom-0 right-0 bg-blue-500 hover:bg-blue-600 dark:bg-blue-600 dark:hover:bg-blue-700 text-white p-3 rounded-full shadow-lg transition-all duration-200 hover:scale-110 disabled:opacity-50"
+                    title="Upload profile picture"
+                  >
+                    {uploading ? (
+                      <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
+                    ) : (
+                      <FaCamera className="text-sm" />
+                    )}
+                  </button>
+                </div>
+
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp"
+                  onChange={handlePictureUpload}
+                  className="hidden"
+                />
+
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+                  Click the camera to upload a new photo
+                </p>
+              </div>
+
+              {/* User Info Section (Non-editable) */}
+              <div className="mb-8 p-4 bg-gray-50/50 dark:bg-gray-900/30 rounded-2xl">
+                <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
+                  Account Information
+                </h3>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div>
+                    <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                      Username
+                    </label>
+                    <p className="text-gray-900 dark:text-white font-light">
+                      {userInfo?.username}
+                    </p>
+                  </div>
+                  <div>
+                    <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                      Email
+                    </label>
+                    <p className="text-gray-900 dark:text-white font-light">
+                      {userInfo?.email}
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              {/* Profile Form Section - Following LoginPage form patterns */}
+              <form onSubmit={handleSubmit} className="space-y-4">
+                {/* Name Fields */}
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <Input
+                    label="First Name"
+                    name="first_name"
+                    type="text"
+                    value={formData.first_name || ""}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    placeholder="Optional"
+                    disabled={saving}
+                    error={errors.first_name}
+                    className={
+                      touchedFields.has("first_name") &&
+                      formData.first_name !== originalFormData.first_name
+                        ? "border-red-300 dark:border-red-500/50"
+                        : ""
+                    }
                   />
-                ) : (
-                  <FaUser className="text-4xl text-gray-400 dark:text-gray-500" />
-                )}
-              </div>
 
-              {/* Camera upload button */}
-              <button
-                onClick={() => fileInputRef.current?.click()}
-                disabled={uploading}
-                className="absolute bottom-0 right-0 bg-blue-500 hover:bg-blue-600 dark:bg-blue-600 dark:hover:bg-blue-700 text-white p-3 rounded-full shadow-lg transition-all duration-200 hover:scale-110 disabled:opacity-50"
-                title="Upload profile picture"
-              >
-                {uploading ? (
-                  <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
-                ) : (
-                  <FaCamera className="text-sm" />
-                )}
-              </button>
-            </div>
+                  <Input
+                    label="Last Name"
+                    name="last_name"
+                    type="text"
+                    value={formData.last_name || ""}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    placeholder="Optional"
+                    disabled={saving}
+                    error={errors.last_name}
+                    className={
+                      touchedFields.has("last_name") &&
+                      formData.last_name !== originalFormData.last_name
+                        ? "border-red-300 dark:border-red-500/50"
+                        : ""
+                    }
+                  />
+                </div>
 
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept="image/jpeg,image/png,image/webp"
-              onChange={handlePictureUpload}
-              className="hidden"
-            />
+                {/* Bio Field */}
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                    Bio
+                  </label>
+                  <textarea
+                    name="bio"
+                    value={formData.bio || ""}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    placeholder="Tell us about yourself..."
+                    disabled={saving}
+                    className={`w-full px-4 py-3 bg-white/80 dark:bg-gray-800/40 backdrop-blur-xl border ${
+                      touchedFields.has("bio") &&
+                      formData.bio !== originalFormData.bio
+                        ? "border-red-300 dark:border-red-500/50"
+                        : "border-gray-200/50 dark:border-gray-700/30"
+                    } rounded-2xl shadow-lg shadow-gray-200/20 dark:shadow-gray-900/20 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500/50 dark:focus:ring-blue-400/50 focus:shadow-xl focus:shadow-blue-500/30 dark:focus:shadow-blue-400/30 focus:scale-[1.02] transition-all duration-300 ease-out font-light resize-none`}
+                    rows={4}
+                    maxLength={1000}
+                  />
+                  {errors.bio && (
+                    <p className="text-red-500 text-sm mt-1">{errors.bio}</p>
+                  )}
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                    {(formData.bio || "").length}/1000 characters
+                  </p>
+                </div>
 
-            <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
-              Click the camera to upload a new photo
-            </p>
-          </div>
+                {/* Form Fields Grid */}
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <LazySelect
+                    label="Occupation"
+                    name="occupation"
+                    value={formData.occupation || ""}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    placeholder="Select your occupation..."
+                    disabled={saving}
+                    error={errors.occupation}
+                    choiceType="occupations"
+                    className={
+                      touchedFields.has("occupation") &&
+                      formData.occupation !== originalFormData.occupation
+                        ? "border-red-300 dark:border-red-500/50"
+                        : ""
+                    }
+                  />
 
-          {/* User Info Section (Non-editable) */}
-          <div className="mb-8 p-4 bg-gray-50/50 dark:bg-gray-900/30 rounded-2xl">
-            <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
-              Account Information
-            </h3>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div>
-                <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                  Username
-                </label>
-                <p className="text-gray-900 dark:text-white font-light">
-                  {userInfo?.username}
-                </p>
-              </div>
-              <div>
-                <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                  Email
-                </label>
-                <p className="text-gray-900 dark:text-white font-light">
-                  {userInfo?.email}
-                </p>
-              </div>
-            </div>
-          </div>
+                  <LazySelect
+                    label="Country"
+                    name="country"
+                    value={formData.country || ""}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    placeholder="Select your country..."
+                    disabled={saving}
+                    error={errors.country}
+                    choiceType="countries"
+                    searchable={true}
+                    className={
+                      touchedFields.has("country") &&
+                      formData.country !== originalFormData.country
+                        ? "border-red-300 dark:border-red-500/50"
+                        : ""
+                    }
+                  />
 
-          {/* Profile Form Section - Following LoginPage form patterns */}
-          <form onSubmit={handleSubmit} className="space-y-4">
-            {/* Name Fields */}
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <Input
-                label="First Name"
-                name="first_name"
-                type="text"
-                value={formData.first_name || ""}
-                onChange={handleChange}
-                onBlur={handleBlur}
-                placeholder="Optional"
-                disabled={saving}
-                error={errors.first_name}
-                className={
-                  touchedFields.has('first_name') && formData.first_name !== originalFormData.first_name
-                    ? 'border-red-300 dark:border-red-500/50'
-                    : ''
-                }
-              />
+                  <LazySelect
+                    label="Primary Language"
+                    name="preferred_language"
+                    value={formData.preferred_language || ""}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    placeholder="Select your primary language..."
+                    disabled={saving}
+                    error={errors.preferred_language}
+                    choiceType="languages"
+                    className={
+                      touchedFields.has("preferred_language") &&
+                      formData.preferred_language !==
+                        originalFormData.preferred_language
+                        ? "border-red-300 dark:border-red-500/50"
+                        : ""
+                    }
+                  />
 
-              <Input
-                label="Last Name"
-                name="last_name"
-                type="text"
-                value={formData.last_name || ""}
-                onChange={handleChange}
-                onBlur={handleBlur}
-                placeholder="Optional"
-                disabled={saving}
-                error={errors.last_name}
-                className={
-                  touchedFields.has('last_name') && formData.last_name !== originalFormData.last_name
-                    ? 'border-red-300 dark:border-red-500/50'
-                    : ''
-                }
-              />
-            </div>
+                  <LazySelect
+                    label="Secondary Language"
+                    name="secondary_language"
+                    value={formData.secondary_language || ""}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    placeholder="Select your secondary language..."
+                    disabled={saving}
+                    error={errors.secondary_language}
+                    choiceType="languages"
+                    className={
+                      touchedFields.has("secondary_language") &&
+                      formData.secondary_language !==
+                        originalFormData.secondary_language
+                        ? "border-red-300 dark:border-red-500/50"
+                        : ""
+                    }
+                  />
+                </div>
 
-            {/* Bio Field */}
-            <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                Bio
-              </label>
-              <textarea
-                name="bio"
-                value={formData.bio || ""}
-                onChange={handleChange}
-                onBlur={handleBlur}
-                placeholder="Tell us about yourself..."
-                disabled={saving}
-                className={`w-full px-4 py-3 bg-white/80 dark:bg-gray-800/40 backdrop-blur-xl border ${
-                  touchedFields.has('bio') && formData.bio !== originalFormData.bio
-                    ? 'border-red-300 dark:border-red-500/50'
-                    : 'border-gray-200/50 dark:border-gray-700/30'
-                } rounded-2xl shadow-lg shadow-gray-200/20 dark:shadow-gray-900/20 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500/50 dark:focus:ring-blue-400/50 focus:shadow-xl focus:shadow-blue-500/30 dark:focus:shadow-blue-400/30 focus:scale-[1.02] transition-all duration-300 ease-out font-light resize-none`}
-                rows={4}
-                maxLength={1000}
-              />
-              {errors.bio && (
-                <p className="text-red-500 text-sm mt-1">{errors.bio}</p>
-              )}
-              <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                {(formData.bio || "").length}/1000 characters
-              </p>
-            </div>
+                <Input
+                  label="Website"
+                  name="website_url"
+                  type="url"
+                  value={formData.website_url || ""}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  placeholder="example.com or https://example.com"
+                  disabled={saving}
+                  error={errors.website_url}
+                  className={
+                    touchedFields.has("website_url") &&
+                    formData.website_url !== originalFormData.website_url
+                      ? "border-red-300 dark:border-red-500/50"
+                      : ""
+                  }
+                />
 
-            {/* Form Fields Grid */}
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <LazySelect
-                label="Occupation"
-                name="occupation"
-                value={formData.occupation || ""}
-                onChange={handleChange}
-                onBlur={handleBlur}
-                placeholder="Select your occupation..."
-                disabled={saving}
-                error={errors.occupation}
-                choiceType="occupations"
-                className={
-                  touchedFields.has('occupation') && formData.occupation !== originalFormData.occupation
-                    ? 'border-red-300 dark:border-red-500/50'
-                    : ''
-                }
-              />
-
-              <LazySelect
-                label="Country"
-                name="country"
-                value={formData.country || ""}
-                onChange={handleChange}
-                onBlur={handleBlur}
-                placeholder="Select your country..."
-                disabled={saving}
-                error={errors.country}
-                choiceType="countries"
-                searchable={true}
-                className={
-                  touchedFields.has('country') && formData.country !== originalFormData.country
-                    ? 'border-red-300 dark:border-red-500/50'
-                    : ''
-                }
-              />
-
-              <LazySelect
-                label="Primary Language"
-                name="preferred_language"
-                value={formData.preferred_language || ""}
-                onChange={handleChange}
-                onBlur={handleBlur}
-                placeholder="Select your primary language..."
-                disabled={saving}
-                error={errors.preferred_language}
-                choiceType="languages"
-                className={
-                  touchedFields.has('preferred_language') && formData.preferred_language !== originalFormData.preferred_language
-                    ? 'border-red-300 dark:border-red-500/50'
-                    : ''
-                }
-              />
-
-              <LazySelect
-                label="Secondary Language"
-                name="secondary_language"
-                value={formData.secondary_language || ""}
-                onChange={handleChange}
-                onBlur={handleBlur}
-                placeholder="Select your secondary language..."
-                disabled={saving}
-                error={errors.secondary_language}
-                choiceType="languages"
-                className={
-                  touchedFields.has('secondary_language') && formData.secondary_language !== originalFormData.secondary_language
-                    ? 'border-red-300 dark:border-red-500/50'
-                    : ''
-                }
-              />
-            </div>
-
-            <Input
-              label="Website"
-              name="website_url"
-              type="url"
-              value={formData.website_url || ""}
-              onChange={handleChange}
-              onBlur={handleBlur}
-              placeholder="example.com or https://example.com"
-              disabled={saving}
-              error={errors.website_url}
-              className={
-                touchedFields.has('website_url') && formData.website_url !== originalFormData.website_url
-                  ? 'border-red-300 dark:border-red-500/50'
-                  : ''
-              }
-            />
-
-            {/* Save Button - Clean navbar style */}
-            <div className="pt-4">
-              <button
-                type="submit"
-                disabled={saving}
-                className="w-full flex items-center justify-center gap-3 px-6 py-3 w-full flex items-center gap-4 px-4 py-3 rounded-xl bg-blue-500/10 hover:bg-blue-500/20 dark:bg-blue-500/10 dark:hover:bg-blue-500/20 transition group cursor-pointer text-white font-medium rounded-xl transition-all duration-200 disabled:opacity-60 disabled:cursor-not-allowed"
-              >
-                {saving ? (
-                  <>
-                    <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white"></div>
-                    <span className="font-medium text-blue-600 dark:text-blue-400 group-hover:text-blue-700 dark:group-hover:text-blue-300">Saving Changes...</span>
-                  </>
-                ) : (
-                  <>
-                    <FaSave className="text-lg text-blue-600 dark:text-blue-400 group-hover:text-blue-700 dark:group-hover:text-blue-300" />
-                    <span className="font-medium text-blue-600 dark:text-blue-400 group-hover:text-blue-700 dark:group-hover:text-blue-300">Save Changes</span>
-                  </>
-                )}
-              </button>
-            </div>
-          </form>
+                {/* Save Button - Clean navbar style */}
+                <div className="pt-4">
+                  <button
+                    type="submit"
+                    disabled={saving}
+                    className="w-full flex items-center justify-center gap-3 px-6 py-3 w-full flex items-center gap-4 px-4 py-3 rounded-xl bg-blue-500/10 hover:bg-blue-500/20 dark:bg-blue-500/10 dark:hover:bg-blue-500/20 transition group cursor-pointer text-white font-medium rounded-xl transition-all duration-200 disabled:opacity-60 disabled:cursor-not-allowed"
+                  >
+                    {saving ? (
+                      <>
+                        <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white"></div>
+                        <span className="font-medium text-blue-600 dark:text-blue-400 group-hover:text-blue-700 dark:group-hover:text-blue-300">
+                          Saving Changes...
+                        </span>
+                      </>
+                    ) : (
+                      <>
+                        <FaSave className="text-lg text-blue-600 dark:text-blue-400 group-hover:text-blue-700 dark:group-hover:text-blue-300" />
+                        <span className="font-medium text-blue-600 dark:text-blue-400 group-hover:text-blue-700 dark:group-hover:text-blue-300">
+                          Save Changes
+                        </span>
+                      </>
+                    )}
+                  </button>
+                </div>
+              </form>
 
               {/* Logout Section - Clean navbar style */}
               <div className="mt-8 pt-6 border-t border-gray-200/30 dark:border-gray-700/30">
@@ -611,7 +688,9 @@ const ProfilePage: React.FC = () => {
                   className="w-full flex items-center justify-center gap-3 px-6 py-3 w-full flex items-center gap-4 px-4 py-3 rounded-xl bg-red-500/10 hover:bg-red-500/20 dark:bg-red-500/10 dark:hover:bg-red-500/20 transition group cursor-pointer text-white font-medium rounded-xl transition-all duration-200"
                 >
                   <FaSignOutAlt className="text-lg text-red-600 dark:text-red-400 group-hover:text-red-700 dark:group-hover:text-red-300" />
-                  <span className="font-medium text-red-600 dark:text-red-400 group-hover:text-red-700 dark:group-hover:text-red-300">Sign Out</span>
+                  <span className="font-medium text-red-600 dark:text-red-400 group-hover:text-red-700 dark:group-hover:text-red-300">
+                    Sign Out
+                  </span>
                 </button>
               </div>
 
@@ -630,9 +709,13 @@ const ProfilePage: React.FC = () => {
                 </button>
 
                 {/* Collapsible content */}
-                <div className={`overflow-hidden transition-all duration-300 ${
-                  showHiddenOptions ? 'max-h-32 opacity-100' : 'max-h-0 opacity-0'
-                }`}>
+                <div
+                  className={`overflow-hidden transition-all duration-300 ${
+                    showHiddenOptions
+                      ? "max-h-32 opacity-100"
+                      : "max-h-0 opacity-0"
+                  }`}
+                >
                   <div className="pt-4">
                     <button
                       onClick={() => setShowDeleteModal(true)}
@@ -652,15 +735,14 @@ const ProfilePage: React.FC = () => {
           {/* Sidebar Section - Takes 1/3 on desktop, full width on mobile */}
           <div className="lg:col-span-1">
             <div className="bg-white/80 dark:bg-gray-800/40 backdrop-blur-xl border border-gray-200/50 dark:border-gray-700/30 rounded-3xl shadow-2xl shadow-gray-200/20 dark:shadow-gray-900/20 p-6">
-
               {/* Tab Navigation */}
               <div className="flex flex-wrap gap-2 mb-6">
                 <button
-                  onClick={() => setActiveTab('friends')}
+                  onClick={() => setActiveTab("friends")}
                   className={`flex items-center gap-2 px-4 py-2 rounded-xl transition-all duration-200 cursor-pointer ${
-                    activeTab === 'friends'
-                      ? 'bg-blue-500/20 text-blue-600 dark:text-blue-400'
-                      : 'bg-gray-100/50 dark:bg-gray-700/30 text-gray-600 dark:text-gray-400 hover:bg-gray-200/50 dark:hover:bg-gray-600/30'
+                    activeTab === "friends"
+                      ? "bg-blue-500/20 text-blue-600 dark:text-blue-400"
+                      : "bg-gray-100/50 dark:bg-gray-700/30 text-gray-600 dark:text-gray-400 hover:bg-gray-200/50 dark:hover:bg-gray-600/30"
                   }`}
                 >
                   <FaUserFriends className="text-lg" />
@@ -668,11 +750,11 @@ const ProfilePage: React.FC = () => {
                 </button>
 
                 <button
-                  onClick={() => setActiveTab('notes')}
+                  onClick={() => setActiveTab("notes")}
                   className={`flex items-center gap-2 px-4 py-2 rounded-xl transition-all duration-200 cursor-pointer ${
-                    activeTab === 'notes'
-                      ? 'bg-blue-500/20 text-blue-600 dark:text-blue-400'
-                      : 'bg-gray-100/50 dark:bg-gray-700/30 text-gray-600 dark:text-gray-400 hover:bg-gray-200/50 dark:hover:bg-gray-600/30'
+                    activeTab === "notes"
+                      ? "bg-blue-500/20 text-blue-600 dark:text-blue-400"
+                      : "bg-gray-100/50 dark:bg-gray-700/30 text-gray-600 dark:text-gray-400 hover:bg-gray-200/50 dark:hover:bg-gray-600/30"
                   }`}
                 >
                   <FaStickyNote className="text-lg" />
@@ -680,11 +762,11 @@ const ProfilePage: React.FC = () => {
                 </button>
 
                 <button
-                  onClick={() => setActiveTab('chats')}
+                  onClick={() => setActiveTab("chats")}
                   className={`flex items-center gap-2 px-4 py-2 rounded-xl transition-all duration-200 cursor-pointer ${
-                    activeTab === 'chats'
-                      ? 'bg-blue-500/20 text-blue-600 dark:text-blue-400'
-                      : 'bg-gray-100/50 dark:bg-gray-700/30 text-gray-600 dark:text-gray-400 hover:bg-gray-200/50 dark:hover:bg-gray-600/30'
+                    activeTab === "chats"
+                      ? "bg-blue-500/20 text-blue-600 dark:text-blue-400"
+                      : "bg-gray-100/50 dark:bg-gray-700/30 text-gray-600 dark:text-gray-400 hover:bg-gray-200/50 dark:hover:bg-gray-600/30"
                   }`}
                 >
                   <FaComments className="text-lg" />
@@ -692,11 +774,11 @@ const ProfilePage: React.FC = () => {
                 </button>
 
                 <button
-                  onClick={() => setActiveTab('courses')}
+                  onClick={() => setActiveTab("courses")}
                   className={`flex items-center gap-2 px-4 py-2 rounded-xl transition-all duration-200 cursor-pointer ${
-                    activeTab === 'courses'
-                      ? 'bg-blue-500/20 text-blue-600 dark:text-blue-400'
-                      : 'bg-gray-100/50 dark:bg-gray-700/30 text-gray-600 dark:text-gray-400 hover:bg-gray-200/50 dark:hover:bg-gray-600/30'
+                    activeTab === "courses"
+                      ? "bg-blue-500/20 text-blue-600 dark:text-blue-400"
+                      : "bg-gray-100/50 dark:bg-gray-700/30 text-gray-600 dark:text-gray-400 hover:bg-gray-200/50 dark:hover:bg-gray-600/30"
                   }`}
                 >
                   <FaGraduationCap className="text-lg" />
@@ -704,11 +786,23 @@ const ProfilePage: React.FC = () => {
                 </button>
 
                 <button
-                  onClick={() => setActiveTab('settings')}
+                  onClick={() => setActiveTab("slideshows")}
                   className={`flex items-center gap-2 px-4 py-2 rounded-xl transition-all duration-200 cursor-pointer ${
-                    activeTab === 'settings'
-                      ? 'bg-blue-500/20 text-blue-600 dark:text-blue-400'
-                      : 'bg-gray-100/50 dark:bg-gray-700/30 text-gray-600 dark:text-gray-400 hover:bg-gray-200/50 dark:hover:bg-gray-600/30'
+                    activeTab === "slideshows"
+                      ? "bg-blue-500/20 text-blue-600 dark:text-blue-400"
+                      : "bg-gray-100/50 dark:bg-gray-700/30 text-gray-600 dark:text-gray-400 hover:bg-gray-200/50 dark:hover:bg-gray-600/30"
+                  }`}
+                >
+                  <FaFilm className="text-lg" />
+                  <span className="font-medium">Slideshows</span>
+                </button>
+
+                <button
+                  onClick={() => setActiveTab("settings")}
+                  className={`flex items-center gap-2 px-4 py-2 rounded-xl transition-all duration-200 cursor-pointer ${
+                    activeTab === "settings"
+                      ? "bg-blue-500/20 text-blue-600 dark:text-blue-400"
+                      : "bg-gray-100/50 dark:bg-gray-700/30 text-gray-600 dark:text-gray-400 hover:bg-gray-200/50 dark:hover:bg-gray-600/30"
                   }`}
                 >
                   <FaCog className="text-lg" />
@@ -718,15 +812,74 @@ const ProfilePage: React.FC = () => {
 
               {/* Content Area */}
               <div className="min-h-[300px]">
-                {activeTab === 'settings' ? (
+                {activeTab === "settings" ? (
                   <PrivacySettings />
+                ) : activeTab === "slideshows" ? (
+                  slideshowsLoading ? (
+                    <div className="flex items-center justify-center p-8">
+                      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
+                    </div>
+                  ) : slideshows.length === 0 ? (
+                    <div className="flex flex-col items-center justify-center text-center p-8">
+                      <FaFilm className="text-5xl text-gray-300 dark:text-gray-600 mx-auto mb-4" />
+                      <h3 className="text-xl font-semibold text-gray-700 dark:text-gray-300 mb-2">
+                        No Slideshows Yet
+                      </h3>
+                      <p className="text-gray-500 dark:text-gray-400 mb-4">
+                        You haven't created any slideshows yet.
+                      </p>
+                      <button
+                        onClick={() => navigate("/slideshows")}
+                        className="px-4 py-2 rounded-xl bg-blue-500/20 text-blue-600 dark:text-blue-400 hover:bg-blue-500/30 transition-all duration-200 font-medium cursor-pointer"
+                      >
+                        Go to Slideshows
+                      </button>
+                    </div>
+                  ) : (
+                    <div className="space-y-3">
+                      {slideshows.map((slideshow) => (
+                        <button
+                          key={slideshow.id}
+                          onClick={() =>
+                            navigate(`/slideshows/${slideshow.id}`)
+                          }
+                          className="w-full text-left p-4 rounded-xl bg-gray-50/50 dark:bg-gray-900/30 hover:bg-gray-100/70 dark:hover:bg-gray-800/50 transition-all duration-200 cursor-pointer"
+                        >
+                          <h4 className="font-medium text-gray-900 dark:text-white truncate">
+                            {slideshow.title}
+                          </h4>
+                          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                            {slideshow.slide_count} slide
+                            {slideshow.slide_count !== 1 ? "s" : ""} · Updated{" "}
+                            {new Date(
+                              slideshow.updated_at,
+                            ).toLocaleDateString()}
+                          </p>
+                        </button>
+                      ))}
+                      <button
+                        onClick={() => navigate("/slideshows")}
+                        className="w-full text-center p-3 rounded-xl text-blue-600 dark:text-blue-400 hover:bg-blue-500/10 transition-all duration-200 font-medium text-sm cursor-pointer"
+                      >
+                        View All Slideshows
+                      </button>
+                    </div>
+                  )
                 ) : (
                   <div className="flex flex-col items-center justify-center text-center p-8">
                     <div className="mb-4">
-                      {activeTab === 'friends' && <FaUserFriends className="text-5xl text-gray-300 dark:text-gray-600 mx-auto" />}
-                      {activeTab === 'notes' && <FaStickyNote className="text-5xl text-gray-300 dark:text-gray-600 mx-auto" />}
-                      {activeTab === 'chats' && <FaComments className="text-5xl text-gray-300 dark:text-gray-600 mx-auto" />}
-                      {activeTab === 'courses' && <FaGraduationCap className="text-5xl text-gray-300 dark:text-gray-600 mx-auto" />}
+                      {activeTab === "friends" && (
+                        <FaUserFriends className="text-5xl text-gray-300 dark:text-gray-600 mx-auto" />
+                      )}
+                      {activeTab === "notes" && (
+                        <FaStickyNote className="text-5xl text-gray-300 dark:text-gray-600 mx-auto" />
+                      )}
+                      {activeTab === "chats" && (
+                        <FaComments className="text-5xl text-gray-300 dark:text-gray-600 mx-auto" />
+                      )}
+                      {activeTab === "courses" && (
+                        <FaGraduationCap className="text-5xl text-gray-300 dark:text-gray-600 mx-auto" />
+                      )}
                     </div>
 
                     <h3 className="text-xl font-semibold text-gray-700 dark:text-gray-300 mb-2 capitalize">
@@ -738,7 +891,7 @@ const ProfilePage: React.FC = () => {
                     </p>
 
                     <p className="text-sm text-gray-600 dark:text-gray-400">
-                      Visit{' '}
+                      Visit{" "}
                       <a
                         href="https://github.com/ibrahim-sisar/EduLite"
                         target="_blank"
@@ -746,8 +899,8 @@ const ProfilePage: React.FC = () => {
                         className="text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300 underline"
                       >
                         https://github.com/ibrahim-sisar/EduLite
-                      </a>
-                      {' '}if you want to contribute!
+                      </a>{" "}
+                      if you want to contribute!
                     </p>
                   </div>
                 )}


### PR DESCRIPTION
# Feature: Profile Page — Add "My Slideshows" Tab (#216)

## Summary

Adds a "Slideshows" tab to the profile page sidebar, replacing one of the "Coming Soon" placeholders with real functionality.

## Changes

### `Frontend/.../pages/ProfilePage.tsx`
- Added `"slideshows"` to the `activeTab` type union (including localStorage persistence)
- Added `FaFilm` icon, `listMySlideshows`, and `SlideshowListItem` imports
- Added `slideshows`, `slideshowsLoading` state and `slideshowsFetched` ref
- Added `useEffect` that lazy-loads the user's slideshows only when the tab is first selected (`listMySlideshows({ page_size: 10 })`)
- Added "Slideshows" tab button between Courses and Settings
- Added three content states:
  - **Loading**: spinner
  - **Empty**: "No Slideshows Yet" message with "Go to Slideshows" button
  - **List**: card per slideshow showing title, slide count, and last updated date — click navigates to detail page. "View All Slideshows" link at the bottom.

## No backend changes

The `GET /api/slideshows/?mine=true` endpoint already exists and returns everything needed.

## Testing
- All 468 frontend tests pass
- TypeScript compiles with zero errors
- Vite build succeeds
