### PR TITLE
mobile editor

### DIFF
--- a/Frontend/EduLiteFrontend/src/components/slideshow/SlideshowViewer.tsx
+++ b/Frontend/EduLiteFrontend/src/components/slideshow/SlideshowViewer.tsx
@@ -22,6 +22,7 @@ import { useSlideNavigation } from "../../hooks/useSlideNavigation";
 import { useSlideLoader } from "../../hooks/useSlideLoader";
 import { usePresentationMode } from "../../hooks/usePresentationMode";
 import { useKeyboardNavigation } from "../../hooks/useKeyboardNavigation";
+import { useSwipeNavigation } from "../../hooks/useSwipeNavigation";
 
 // Subject name mappings
 const SUBJECTS: Record<string, string> = {
@@ -155,6 +156,12 @@ const SlideshowViewer: React.FC<SlideshowViewerProps> = ({
     onExit,
     slideCount,
     allowFullscreen,
+  });
+
+  // Swipe navigation for mobile
+  useSwipeNavigation(containerRef, {
+    onSwipeLeft: navigation.next,
+    onSwipeRight: navigation.prev,
   });
 
   // Navigation handler for edit
@@ -362,8 +369,8 @@ const SlideshowViewer: React.FC<SlideshowViewerProps> = ({
           />
         </div>
 
-        {/* Navigation Arrows (always visible on desktop) */}
-        <div className="absolute left-4 top-1/2 -translate-y-1/2 hidden md:block pointer-events-none z-10">
+        {/* Navigation Arrows */}
+        <div className="absolute left-2 md:left-4 top-1/2 -translate-y-1/2 pointer-events-none z-10">
           <button
             onClick={navigation.prev}
             onWheel={(e) => {
@@ -373,14 +380,14 @@ const SlideshowViewer: React.FC<SlideshowViewerProps> = ({
               if (scrollable) scrollable.scrollTop += e.deltaY;
             }}
             disabled={navigation.isFirst}
-            className="p-4 rounded-full bg-white/90 dark:bg-gray-800/90 hover:bg-white dark:hover:bg-gray-700 backdrop-blur-lg text-gray-900 dark:text-gray-100 hover:text-gray-900 dark:hover:text-white transition-all disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer shadow-lg pointer-events-auto"
+            className="p-2 md:p-4 rounded-full bg-white/90 dark:bg-gray-800/90 hover:bg-white dark:hover:bg-gray-700 backdrop-blur-lg text-gray-900 dark:text-gray-100 hover:text-gray-900 dark:hover:text-white transition-all disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer shadow-lg pointer-events-auto"
             aria-label="Previous slide"
           >
-            <HiArrowLeft className="w-6 h-6" />
+            <HiArrowLeft className="w-4 h-4 md:w-6 md:h-6" />
           </button>
         </div>
 
-        <div className="absolute right-4 top-1/2 -translate-y-1/2 hidden md:block pointer-events-none z-10">
+        <div className="absolute right-2 md:right-4 top-1/2 -translate-y-1/2 pointer-events-none z-10">
           <button
             onClick={navigation.next}
             onWheel={(e) => {
@@ -390,10 +397,10 @@ const SlideshowViewer: React.FC<SlideshowViewerProps> = ({
               if (scrollable) scrollable.scrollTop += e.deltaY;
             }}
             disabled={navigation.isLast}
-            className="p-4 rounded-full bg-white/90 dark:bg-gray-800/90 hover:bg-white dark:hover:bg-gray-700 backdrop-blur-lg text-gray-900 dark:text-gray-100 hover:text-gray-900 dark:hover:text-white transition-all disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer shadow-lg pointer-events-auto"
+            className="p-2 md:p-4 rounded-full bg-white/90 dark:bg-gray-800/90 hover:bg-white dark:hover:bg-gray-700 backdrop-blur-lg text-gray-900 dark:text-gray-100 hover:text-gray-900 dark:hover:text-white transition-all disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer shadow-lg pointer-events-auto"
             aria-label="Next slide"
           >
-            <HiArrowRight className="w-6 h-6" />
+            <HiArrowRight className="w-4 h-4 md:w-6 md:h-6" />
           </button>
         </div>
       </div>

--- a/Frontend/EduLiteFrontend/src/components/slideshow/editor/EditorHeader.tsx
+++ b/Frontend/EduLiteFrontend/src/components/slideshow/editor/EditorHeader.tsx
@@ -58,45 +58,47 @@ export function EditorHeader({
             value={title}
             onChange={(e) => onTitleChange(e.target.value)}
             placeholder="Untitled Slideshow"
-            className="flex-1 text-lg font-semibold bg-transparent text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 border-none focus:outline-none focus:ring-2 focus:ring-blue-500 rounded px-2 py-1 min-w-0"
+            className="flex-1 text-base sm:text-lg font-semibold bg-transparent text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 border-none focus:outline-none focus:ring-2 focus:ring-blue-500 rounded px-2 py-1 min-w-0"
           />
         </div>
 
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2 sm:gap-3">
           <button
             type="button"
             onClick={onSaveClick}
             disabled={!isDirty}
-            className="px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer text-white rounded-lg font-medium transition-colors flex items-center gap-2"
+            className="px-3 sm:px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer text-white rounded-lg font-medium transition-colors flex items-center gap-2"
           >
             <HiSave className="w-5 h-5" />
-            Save
+            <span className="hidden sm:inline">Save</span>
           </button>
 
           <button
             type="button"
             onClick={() => setShowShortcuts(true)}
-            className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors cursor-pointer"
+            className="hidden sm:block p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors cursor-pointer"
             title="Keyboard shortcuts"
           >
             <BsKeyboard className="w-5 h-5 text-gray-600 dark:text-gray-400" />
           </button>
 
-          <SaveStatusIndicator
-            status={saveStatus}
-            lastSaved={lastSaved}
-            error={saveError}
-          />
+          <div className="hidden sm:block">
+            <SaveStatusIndicator
+              status={saveStatus}
+              lastSaved={lastSaved}
+              error={saveError}
+            />
+          </div>
 
           <button
             type="button"
             onClick={onPresentClick}
             disabled={!canPresent}
-            className="px-4 py-2 bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100 hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer rounded-lg font-medium transition-colors flex items-center gap-2"
+            className="px-3 sm:px-4 py-2 bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100 hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer rounded-lg font-medium transition-colors flex items-center gap-2"
             title={!canPresent ? "Add slides to present" : "Present slideshow"}
           >
             <HiEye className="w-5 h-5" />
-            Present
+            <span className="hidden sm:inline">Present</span>
           </button>
         </div>
       </div>

--- a/Frontend/EduLiteFrontend/src/hooks/useSwipeNavigation.ts
+++ b/Frontend/EduLiteFrontend/src/hooks/useSwipeNavigation.ts
@@ -1,0 +1,48 @@
+import { useEffect, useRef, type RefObject } from "react";
+
+interface UseSwipeNavigationOptions {
+  onSwipeLeft: () => void;
+  onSwipeRight: () => void;
+  threshold?: number;
+}
+
+export function useSwipeNavigation<T extends HTMLElement>(
+  containerRef: RefObject<T | null>,
+  { onSwipeLeft, onSwipeRight, threshold = 50 }: UseSwipeNavigationOptions,
+) {
+  const touchStartX = useRef(0);
+  const touchStartY = useRef(0);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const handleTouchStart = (e: TouchEvent) => {
+      touchStartX.current = e.touches[0].clientX;
+      touchStartY.current = e.touches[0].clientY;
+    };
+
+    const handleTouchEnd = (e: TouchEvent) => {
+      const deltaX = e.changedTouches[0].clientX - touchStartX.current;
+      const deltaY = e.changedTouches[0].clientY - touchStartY.current;
+
+      // Only trigger if horizontal movement exceeds threshold
+      // and is greater than vertical movement (avoid hijacking scroll)
+      if (Math.abs(deltaX) > threshold && Math.abs(deltaX) > Math.abs(deltaY)) {
+        if (deltaX < 0) {
+          onSwipeLeft();
+        } else {
+          onSwipeRight();
+        }
+      }
+    };
+
+    el.addEventListener("touchstart", handleTouchStart, { passive: true });
+    el.addEventListener("touchend", handleTouchEnd, { passive: true });
+
+    return () => {
+      el.removeEventListener("touchstart", handleTouchStart);
+      el.removeEventListener("touchend", handleTouchEnd);
+    };
+  }, [containerRef, onSwipeLeft, onSwipeRight, threshold]);
+}

--- a/Frontend/EduLiteFrontend/src/pages/SlideshowEditorPage.tsx
+++ b/Frontend/EduLiteFrontend/src/pages/SlideshowEditorPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import toast from "react-hot-toast";
 import { HiXMark } from "react-icons/hi2";
+import { HiViewList, HiPencilAlt, HiEye } from "react-icons/hi";
 import {
   EditorHeader,
   SlideList,
@@ -50,6 +51,9 @@ export default function SlideshowEditorPage() {
   const [saveError, setSaveError] = useState<string | null>(null);
   const [isDirty, setIsDirty] = useState(false);
   const [showPreview] = useState(true);
+  const [mobilePanel, setMobilePanel] = useState<
+    "slides" | "editor" | "preview"
+  >("editor");
   const [showPresentModal, setShowPresentModal] = useState(false);
 
   // Warn about unsaved changes
@@ -524,12 +528,54 @@ export default function SlideshowEditorPage() {
         canPresent={slides.length > 0 && !isNewSlideshow}
       />
 
+      {/* Mobile Panel Tabs */}
+      <div className="flex md:hidden border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
+        <button
+          onClick={() => setMobilePanel("slides")}
+          className={`flex-1 flex items-center justify-center gap-1.5 py-2 text-sm font-medium transition-colors cursor-pointer ${
+            mobilePanel === "slides"
+              ? "text-blue-600 dark:text-blue-400 border-b-2 border-blue-600 dark:border-blue-400"
+              : "text-gray-500 dark:text-gray-400"
+          }`}
+        >
+          <HiViewList className="w-4 h-4" />
+          Slides
+        </button>
+        <button
+          onClick={() => setMobilePanel("editor")}
+          className={`flex-1 flex items-center justify-center gap-1.5 py-2 text-sm font-medium transition-colors cursor-pointer ${
+            mobilePanel === "editor"
+              ? "text-blue-600 dark:text-blue-400 border-b-2 border-blue-600 dark:border-blue-400"
+              : "text-gray-500 dark:text-gray-400"
+          }`}
+        >
+          <HiPencilAlt className="w-4 h-4" />
+          Editor
+        </button>
+        <button
+          onClick={() => setMobilePanel("preview")}
+          className={`flex-1 flex items-center justify-center gap-1.5 py-2 text-sm font-medium transition-colors cursor-pointer ${
+            mobilePanel === "preview"
+              ? "text-blue-600 dark:text-blue-400 border-b-2 border-blue-600 dark:border-blue-400"
+              : "text-gray-500 dark:text-gray-400"
+          }`}
+        >
+          <HiEye className="w-4 h-4" />
+          Preview
+        </button>
+      </div>
+
       <div className="flex-1 flex overflow-hidden">
-        <div className="w-64 border-r border-gray-200 dark:border-gray-700">
+        <div
+          className={`w-full md:w-64 border-r border-gray-200 dark:border-gray-700 ${mobilePanel === "slides" ? "block" : "hidden"} md:block`}
+        >
           <SlideList
             slides={slides}
             selectedId={selectedSlideId}
-            onSelect={setSelectedSlideId}
+            onSelect={(id) => {
+              setSelectedSlideId(id);
+              setMobilePanel("editor");
+            }}
             onAdd={handleAddSlide}
             onDelete={handleDeleteSlide}
             onReorder={handleReorderSlides}
@@ -537,7 +583,9 @@ export default function SlideshowEditorPage() {
           />
         </div>
 
-        <div className={showPreview ? "flex-1" : "flex-[2]"}>
+        <div
+          className={`w-full ${showPreview ? "md:flex-1" : "md:flex-[2]"} ${mobilePanel === "editor" ? "block" : "hidden"} md:block`}
+        >
           <SlideEditor
             slide={selectedSlide}
             onChange={(updates) =>
@@ -547,7 +595,9 @@ export default function SlideshowEditorPage() {
         </div>
 
         {showPreview && (
-          <div className="flex-1">
+          <div
+            className={`w-full md:flex-1 ${mobilePanel === "preview" ? "block" : "hidden"} md:block`}
+          >
             <SlidePreview
               slide={selectedSlide}
               isVisible={showPreview}


### PR DESCRIPTION
# Fix: Mobile Presentation & Editor — Navigation and Responsiveness (#217)

## Summary

The presentation viewer had no navigation controls on mobile, and the slideshow editor was completely unusable on small screens. This PR fixes both.

## Presentation Viewer

### Visible arrows on mobile
- Removed `hidden md:block` from nav arrow containers — arrows now show on all screen sizes
- Smaller buttons on mobile: `p-2 md:p-4`, `w-4 h-4 md:w-6 md:h-6`, `left-2 md:left-4`

### Swipe navigation
- Created `src/hooks/useSwipeNavigation.ts` — attaches `touchstart`/`touchend` listeners to a container ref
- Fires on horizontal swipes > 50px that exceed vertical movement (won't hijack scrolling)
- Wired into `SlideshowViewer.tsx` on the main container ref

## Editor Responsiveness

### Tab-based mobile layout (`SlideshowEditorPage.tsx`)
- Added `mobilePanel` state (`"slides" | "editor" | "preview"`)
- Added a mobile tab bar (`md:hidden`) with Slides / Editor / Preview buttons
- On mobile, only the active panel is shown full-width
- Selecting a slide in the list auto-switches to the editor tab
- Desktop layout is completely unchanged

### Compact header (`EditorHeader.tsx`)
- Save and Present buttons: icon-only on mobile, icon + text on `sm`+
- Keyboard shortcuts button: hidden on mobile
- Save status indicator: hidden on mobile
- Title input: `text-base sm:text-lg`

## Files changed
- `src/hooks/useSwipeNavigation.ts` (new)
- `src/components/slideshow/SlideshowViewer.tsx`
- `src/pages/SlideshowEditorPage.tsx`
- `src/components/slideshow/editor/EditorHeader.tsx`

## Testing
- All 468 frontend tests pass
- TypeScript compiles with zero errors
