### PR TITLE
clean up auth clunkiness

### DIFF
--- a/Frontend/EduLiteFrontend/src/services/__tests__/tokenService.test.ts
+++ b/Frontend/EduLiteFrontend/src/services/__tests__/tokenService.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import axios from 'axios';
-import toast from 'react-hot-toast';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import axios from "axios";
+import toast from "react-hot-toast";
 import {
   getStoredTokens,
   setStoredTokens,
@@ -12,14 +12,14 @@ import {
   setupAxiosInterceptors,
   shouldBeAuthenticated,
   initializeTokenService,
-} from '../tokenService';
+} from "../tokenService";
 
 // Mock axios
-vi.mock('axios');
+vi.mock("axios");
 const mockedAxios = vi.mocked(axios, { deep: true });
 
 // Mock react-hot-toast
-vi.mock('react-hot-toast', () => ({
+vi.mock("react-hot-toast", () => ({
   default: {
     error: vi.fn(),
     success: vi.fn(),
@@ -31,64 +31,64 @@ vi.mock('react-hot-toast', () => ({
  * Creates valid/expired JWT tokens for testing
  */
 const createJWT = (expiresInSeconds: number): string => {
-  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const header = btoa(JSON.stringify({ alg: "HS256", typ: "JWT" }));
   const payload = btoa(
     JSON.stringify({
       exp: Math.floor(Date.now() / 1000) + expiresInSeconds,
       user_id: 1,
-      username: 'testuser',
-    })
+      username: "testuser",
+    }),
   );
   return `${header}.${payload}.fake-signature`;
 };
 
-describe('tokenService - Storage Functions', () => {
+describe("tokenService - Storage Functions", () => {
   beforeEach(() => {
     localStorage.clear();
     sessionStorage.clear();
     vi.clearAllMocks();
   });
 
-  describe('getStoredTokens', () => {
-    it('returns null tokens when storage is empty', () => {
+  describe("getStoredTokens", () => {
+    it("returns null tokens when storage is empty", () => {
       const tokens = getStoredTokens();
       expect(tokens).toEqual({ access: null, refresh: null });
     });
 
-    it('returns tokens from storage', () => {
-      setStoredTokens('access-token', 'refresh-token');
+    it("returns tokens from storage", () => {
+      setStoredTokens("access-token", "refresh-token");
 
       const tokens = getStoredTokens();
       expect(tokens).toEqual({
-        access: 'access-token',
-        refresh: 'refresh-token',
+        access: "access-token",
+        refresh: "refresh-token",
       });
     });
   });
 
-  describe('setStoredTokens', () => {
-    it('stores tokens in storage', () => {
-      setStoredTokens('new-access', 'new-refresh');
+  describe("setStoredTokens", () => {
+    it("stores tokens in storage", () => {
+      setStoredTokens("new-access", "new-refresh");
 
       // Verify tokens are retrievable
       const tokens = getStoredTokens();
-      expect(tokens.access).toBe('new-access');
-      expect(tokens.refresh).toBe('new-refresh');
+      expect(tokens.access).toBe("new-access");
+      expect(tokens.refresh).toBe("new-refresh");
     });
 
-    it('overwrites existing tokens', () => {
-      setStoredTokens('old-access', 'old-refresh');
-      setStoredTokens('new-access', 'new-refresh');
+    it("overwrites existing tokens", () => {
+      setStoredTokens("old-access", "old-refresh");
+      setStoredTokens("new-access", "new-refresh");
 
       const tokens = getStoredTokens();
-      expect(tokens.access).toBe('new-access');
-      expect(tokens.refresh).toBe('new-refresh');
+      expect(tokens.access).toBe("new-access");
+      expect(tokens.refresh).toBe("new-refresh");
     });
   });
 
-  describe('clearStoredTokens', () => {
-    it('removes tokens from storage', () => {
-      setStoredTokens('access-token', 'refresh-token');
+  describe("clearStoredTokens", () => {
+    it("removes tokens from storage", () => {
+      setStoredTokens("access-token", "refresh-token");
       clearStoredTokens();
 
       const tokens = getStoredTokens();
@@ -96,60 +96,60 @@ describe('tokenService - Storage Functions', () => {
       expect(tokens.refresh).toBeNull();
     });
 
-    it('does not throw error when storage is already empty', () => {
+    it("does not throw error when storage is already empty", () => {
       expect(() => clearStoredTokens()).not.toThrow();
     });
   });
 });
 
-describe('tokenService - Token Validation', () => {
+describe("tokenService - Token Validation", () => {
   beforeEach(() => {
     localStorage.clear();
     vi.clearAllMocks();
   });
 
-  describe('isTokenExpired', () => {
-    it('returns true for empty string token', () => {
-      expect(isTokenExpired('')).toBe(true);
+  describe("isTokenExpired", () => {
+    it("returns true for empty string token", () => {
+      expect(isTokenExpired("")).toBe(true);
     });
 
-    it('returns true for null/undefined token', () => {
+    it("returns true for null/undefined token", () => {
       expect(isTokenExpired(null as any)).toBe(true);
       expect(isTokenExpired(undefined as any)).toBe(true);
     });
 
-    it('returns true for malformed JWT (no dots)', () => {
-      expect(isTokenExpired('malformed-token')).toBe(true);
+    it("returns true for malformed JWT (no dots)", () => {
+      expect(isTokenExpired("malformed-token")).toBe(true);
     });
 
-    it('returns true for JWT with invalid base64 payload', () => {
-      expect(isTokenExpired('header.!!!invalid!!!.signature')).toBe(true);
+    it("returns true for JWT with invalid base64 payload", () => {
+      expect(isTokenExpired("header.!!!invalid!!!.signature")).toBe(true);
     });
 
-    it('returns false for valid non-expired token', () => {
+    it("returns false for valid non-expired token", () => {
       const validToken = createJWT(3600); // Expires in 1 hour
       expect(isTokenExpired(validToken)).toBe(false);
     });
 
-    it('returns true for expired token', () => {
+    it("returns true for expired token", () => {
       const expiredToken = createJWT(-3600); // Expired 1 hour ago
       expect(isTokenExpired(expiredToken)).toBe(true);
     });
 
-    it('returns true for token expiring within buffer time (30 seconds)', () => {
+    it("returns true for token expiring within buffer time (30 seconds)", () => {
       // Token expires in 20 seconds (within 30-second buffer)
       const aboutToExpireToken = createJWT(20);
       expect(isTokenExpired(aboutToExpireToken)).toBe(true);
     });
 
-    it('returns false for token expiring after buffer time', () => {
+    it("returns false for token expiring after buffer time", () => {
       // Token expires in 60 seconds (beyond 30-second buffer)
       const validToken = createJWT(60);
       expect(isTokenExpired(validToken)).toBe(false);
     });
 
-    it('handles token with missing exp field', () => {
-      const header = btoa(JSON.stringify({ alg: 'HS256' }));
+    it("handles token with missing exp field", () => {
+      const header = btoa(JSON.stringify({ alg: "HS256" }));
       const payload = btoa(JSON.stringify({ user_id: 1 })); // No exp
       const tokenWithoutExp = `${header}.${payload}.signature`;
 
@@ -159,29 +159,29 @@ describe('tokenService - Token Validation', () => {
     });
   });
 
-  describe('shouldBeAuthenticated', () => {
-    it('returns false when no tokens in storage', () => {
+  describe("shouldBeAuthenticated", () => {
+    it("returns false when no tokens in storage", () => {
       expect(shouldBeAuthenticated()).toBe(false);
     });
 
-    it('returns false when only access token exists', () => {
-      setStoredTokens(createJWT(3600), 'temp');
+    it("returns false when only access token exists", () => {
+      setStoredTokens(createJWT(3600), "temp");
       clearStoredTokens();
-      localStorage.setItem('access', createJWT(3600));
+      localStorage.setItem("access", createJWT(3600));
       expect(shouldBeAuthenticated()).toBe(false);
     });
 
-    it('returns false when only refresh token exists', () => {
-      localStorage.setItem('refresh', createJWT(3600));
+    it("returns false when only refresh token exists", () => {
+      localStorage.setItem("refresh", createJWT(3600));
       expect(shouldBeAuthenticated()).toBe(false);
     });
 
-    it('returns true when both tokens exist and refresh is valid', () => {
+    it("returns true when both tokens exist and refresh is valid", () => {
       setStoredTokens(createJWT(3600), createJWT(3600));
       expect(shouldBeAuthenticated()).toBe(true);
     });
 
-    it('returns false and clears tokens when refresh token is expired', () => {
+    it("returns false and clears tokens when refresh token is expired", () => {
       setStoredTokens(createJWT(3600), createJWT(-3600)); // Expired refresh
 
       expect(shouldBeAuthenticated()).toBe(false);
@@ -191,7 +191,7 @@ describe('tokenService - Token Validation', () => {
       expect(tokens.refresh).toBeNull();
     });
 
-    it('returns true even if access token is expired (as long as refresh is valid)', () => {
+    it("returns true even if access token is expired (as long as refresh is valid)", () => {
       setStoredTokens(createJWT(-100), createJWT(3600)); // Expired access, valid refresh
 
       expect(shouldBeAuthenticated()).toBe(true);
@@ -199,27 +199,59 @@ describe('tokenService - Token Validation', () => {
   });
 });
 
-describe('tokenService - Token Refresh', () => {
+describe("tokenService - Token Refresh", () => {
   beforeEach(() => {
     localStorage.clear();
     vi.clearAllMocks();
   });
 
-  describe('refreshAccessToken', () => {
-    it('throws error when no refresh token in storage', async () => {
-      await expect(refreshAccessToken()).rejects.toThrow(/refresh token|Failed to refresh/i);
+  describe("refreshAccessToken", () => {
+    it("throws error when no refresh token in storage", async () => {
+      await expect(refreshAccessToken()).rejects.toThrow(
+        /refresh token|Failed to refresh/i,
+      );
     });
 
-    it('throws error when refresh token is expired', async () => {
-      setStoredTokens('access', createJWT(-3600)); // Expired refresh
+    it("throws error when refresh token is expired", async () => {
+      setStoredTokens("access", createJWT(-3600)); // Expired refresh
 
-      await expect(refreshAccessToken()).rejects.toThrow('Refresh token expired');
+      await expect(refreshAccessToken()).rejects.toThrow(
+        "Refresh token expired",
+      );
     });
 
-    it('successfully refreshes access token', async () => {
+    it("successfully refreshes and stores both tokens when rotation is enabled", async () => {
       const refreshToken = createJWT(3600);
       const newAccessToken = createJWT(3600);
-      setStoredTokens('old-access', refreshToken);
+      const newRefreshToken = createJWT(7200);
+      setStoredTokens("old-access", refreshToken);
+
+      mockedAxios.post.mockResolvedValueOnce({
+        data: { access: newAccessToken, refresh: newRefreshToken },
+      });
+
+      const result = await refreshAccessToken();
+
+      expect(result).toBe(newAccessToken);
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        expect.stringContaining("/token/refresh/"),
+        { refresh: refreshToken },
+        {
+          headers: { "Content-Type": "application/json" },
+          timeout: 10000,
+        },
+      );
+
+      // Verify both tokens were stored
+      const tokens = getStoredTokens();
+      expect(tokens.access).toBe(newAccessToken);
+      expect(tokens.refresh).toBe(newRefreshToken);
+    });
+
+    it("preserves existing refresh token when server does not return one", async () => {
+      const refreshToken = createJWT(3600);
+      const newAccessToken = createJWT(3600);
+      setStoredTokens("old-access", refreshToken);
 
       mockedAxios.post.mockResolvedValueOnce({
         data: { access: newAccessToken },
@@ -228,40 +260,37 @@ describe('tokenService - Token Refresh', () => {
       const result = await refreshAccessToken();
 
       expect(result).toBe(newAccessToken);
-      expect(mockedAxios.post).toHaveBeenCalledWith(
-        expect.stringContaining('/token/refresh/'),
-        { refresh: refreshToken },
-        {
-          headers: { 'Content-Type': 'application/json' },
-          timeout: 10000,
-        }
-      );
 
-      // Verify new token was stored
+      // Access token updated, refresh token unchanged
       const tokens = getStoredTokens();
       expect(tokens.access).toBe(newAccessToken);
+      expect(tokens.refresh).toBe(refreshToken);
     });
 
-    it('clears tokens on 401 response', async () => {
+    it("clears tokens on 401 response", async () => {
       setStoredTokens(createJWT(3600), createJWT(3600));
 
       mockedAxios.post.mockRejectedValueOnce({
         response: { status: 401 },
       });
 
-      await expect(refreshAccessToken()).rejects.toThrow('Refresh token expired or invalid');
+      await expect(refreshAccessToken()).rejects.toThrow(
+        "Refresh token expired or invalid",
+      );
 
       const tokens = getStoredTokens();
       expect(tokens.access).toBeNull();
       expect(tokens.refresh).toBeNull();
     });
 
-    it('clears tokens on network error', async () => {
+    it("clears tokens on network error", async () => {
       setStoredTokens(createJWT(3600), createJWT(3600));
 
-      mockedAxios.post.mockRejectedValueOnce(new Error('Network error'));
+      mockedAxios.post.mockRejectedValueOnce(new Error("Network error"));
 
-      await expect(refreshAccessToken()).rejects.toThrow('Failed to refresh access token');
+      await expect(refreshAccessToken()).rejects.toThrow(
+        "Failed to refresh access token",
+      );
 
       const tokens = getStoredTokens();
       expect(tokens.access).toBeNull();
@@ -269,12 +298,14 @@ describe('tokenService - Token Refresh', () => {
     });
   });
 
-  describe('getValidAccessToken', () => {
-    it('throws error when no tokens exist', async () => {
-      await expect(getValidAccessToken()).rejects.toThrow('No authentication tokens available');
+  describe("getValidAccessToken", () => {
+    it("throws error when no tokens exist", async () => {
+      await expect(getValidAccessToken()).rejects.toThrow(
+        "No authentication tokens available",
+      );
     });
 
-    it('returns access token directly when not expired', async () => {
+    it("returns access token directly when not expired", async () => {
       const validAccessToken = createJWT(3600);
       setStoredTokens(validAccessToken, createJWT(3600));
 
@@ -284,13 +315,14 @@ describe('tokenService - Token Refresh', () => {
       expect(mockedAxios.post).not.toHaveBeenCalled(); // No refresh needed
     });
 
-    it('refreshes and returns new token when access token is expired', async () => {
+    it("refreshes and returns new token when access token is expired", async () => {
       const expiredAccessToken = createJWT(-100);
       const newAccessToken = createJWT(3600);
+      const newRefreshToken = createJWT(7200);
       setStoredTokens(expiredAccessToken, createJWT(3600));
 
       mockedAxios.post.mockResolvedValueOnce({
-        data: { access: newAccessToken },
+        data: { access: newAccessToken, refresh: newRefreshToken },
       });
 
       const result = await getValidAccessToken();
@@ -299,21 +331,32 @@ describe('tokenService - Token Refresh', () => {
       expect(mockedAxios.post).toHaveBeenCalledTimes(1);
     });
 
-    it('queues concurrent requests during refresh', async () => {
+    it("queues concurrent requests during refresh", async () => {
       const expiredAccessToken = createJWT(-100);
       const newAccessToken = createJWT(3600);
+      const newRefreshToken = createJWT(7200);
       setStoredTokens(expiredAccessToken, createJWT(3600));
 
       // Simulate slow refresh
       mockedAxios.post.mockImplementation(
         () =>
           new Promise((resolve) =>
-            setTimeout(() => resolve({ data: { access: newAccessToken } }), 100)
-          )
+            setTimeout(
+              () =>
+                resolve({
+                  data: { access: newAccessToken, refresh: newRefreshToken },
+                }),
+              100,
+            ),
+          ),
       );
 
       // Make 3 concurrent requests
-      const promises = [getValidAccessToken(), getValidAccessToken(), getValidAccessToken()];
+      const promises = [
+        getValidAccessToken(),
+        getValidAccessToken(),
+        getValidAccessToken(),
+      ];
 
       const results = await Promise.all(promises);
 
@@ -323,27 +366,31 @@ describe('tokenService - Token Refresh', () => {
       expect(mockedAxios.post).toHaveBeenCalledTimes(1);
     });
 
-    it('propagates error to queued requests when refresh fails', async () => {
+    it("propagates error to queued requests when refresh fails", async () => {
       const expiredAccessToken = createJWT(-100);
       setStoredTokens(expiredAccessToken, createJWT(3600));
 
-      mockedAxios.post.mockRejectedValueOnce(new Error('Refresh failed'));
+      mockedAxios.post.mockRejectedValueOnce(new Error("Refresh failed"));
 
-      const promises = [getValidAccessToken(), getValidAccessToken(), getValidAccessToken()];
+      const promises = [
+        getValidAccessToken(),
+        getValidAccessToken(),
+        getValidAccessToken(),
+      ];
 
       await expect(Promise.all(promises)).rejects.toThrow(/failed|refresh/i);
     });
   });
 });
 
-describe('tokenService - Setup & Handlers', () => {
+describe("tokenService - Setup & Handlers", () => {
   beforeEach(() => {
     localStorage.clear();
     vi.clearAllMocks();
   });
 
-  describe('setLogoutHandler', () => {
-    it('registers logout handler callback', () => {
+  describe("setLogoutHandler", () => {
+    it("registers logout handler callback", () => {
       const logoutHandler = vi.fn();
       setLogoutHandler(logoutHandler);
 
@@ -352,9 +399,9 @@ describe('tokenService - Setup & Handlers', () => {
     });
   });
 
-  describe('initializeTokenService', () => {
-    it('sets up axios interceptors', () => {
-      const interceptorsSpy = vi.spyOn(axios.interceptors.request, 'use');
+  describe("initializeTokenService", () => {
+    it("sets up axios interceptors", () => {
+      const interceptorsSpy = vi.spyOn(axios.interceptors.request, "use");
 
       initializeTokenService();
 
@@ -363,7 +410,7 @@ describe('tokenService - Setup & Handlers', () => {
   });
 });
 
-describe('tokenService - Axios Interceptors', () => {
+describe("tokenService - Axios Interceptors", () => {
   beforeEach(() => {
     localStorage.clear();
     vi.clearAllMocks();
@@ -375,18 +422,19 @@ describe('tokenService - Axios Interceptors', () => {
     } as any;
   });
 
-  describe('Request Interceptor', () => {
-    it('adds Authorization header to requests with valid token', async () => {
+  describe("Request Interceptor", () => {
+    it("adds Authorization header to requests with valid token", async () => {
       const validAccessToken = createJWT(3600);
       setStoredTokens(validAccessToken, createJWT(3600));
 
       setupAxiosInterceptors();
 
       // Get the request interceptor callback
-      const requestInterceptor = (mockedAxios.interceptors.request.use as any).mock.calls[0][0];
+      const requestInterceptor = (mockedAxios.interceptors.request.use as any)
+        .mock.calls[0][0];
 
       const config = {
-        url: '/api/profile/',
+        url: "/api/profile/",
         headers: {},
       };
 
@@ -395,13 +443,14 @@ describe('tokenService - Axios Interceptors', () => {
       expect(result.headers.Authorization).toBe(`Bearer ${validAccessToken}`);
     });
 
-    it('skips token injection for /token/ endpoints', async () => {
+    it("skips token injection for /token/ endpoints", async () => {
       setupAxiosInterceptors();
 
-      const requestInterceptor = (mockedAxios.interceptors.request.use as any).mock.calls[0][0];
+      const requestInterceptor = (mockedAxios.interceptors.request.use as any)
+        .mock.calls[0][0];
 
       const config = {
-        url: '/api/token/refresh/',
+        url: "/api/token/refresh/",
         headers: {},
       };
 
@@ -410,13 +459,14 @@ describe('tokenService - Axios Interceptors', () => {
       expect(result.headers.Authorization).toBeUndefined();
     });
 
-    it('skips token injection for /register/ endpoints', async () => {
+    it("skips token injection for /register/ endpoints", async () => {
       setupAxiosInterceptors();
 
-      const requestInterceptor = (mockedAxios.interceptors.request.use as any).mock.calls[0][0];
+      const requestInterceptor = (mockedAxios.interceptors.request.use as any)
+        .mock.calls[0][0];
 
       const config = {
-        url: '/api/register/',
+        url: "/api/register/",
         headers: {},
       };
 
@@ -425,16 +475,17 @@ describe('tokenService - Axios Interceptors', () => {
       expect(result.headers.Authorization).toBeUndefined();
     });
 
-    it('does not block request when token retrieval fails', async () => {
+    it("does not block request when token retrieval fails", async () => {
       // Ensure no tokens exist by clearing and not setting any
       clearStoredTokens();
 
       setupAxiosInterceptors();
 
-      const requestInterceptor = (mockedAxios.interceptors.request.use as any).mock.calls[0][0];
+      const requestInterceptor = (mockedAxios.interceptors.request.use as any)
+        .mock.calls[0][0];
 
       const config = {
-        url: '/api/profile/',
+        url: "/api/profile/",
         headers: {},
       };
 
@@ -446,14 +497,15 @@ describe('tokenService - Axios Interceptors', () => {
     });
   });
 
-  describe('Response Interceptor', () => {
-    it('returns response directly on success', async () => {
+  describe("Response Interceptor", () => {
+    it("returns response directly on success", async () => {
       setupAxiosInterceptors();
 
-      const responseInterceptor = (mockedAxios.interceptors.response.use as any).mock.calls[0][0];
+      const responseInterceptor = (mockedAxios.interceptors.response.use as any)
+        .mock.calls[0][0];
 
       const response = {
-        data: { message: 'success' },
+        data: { message: "success" },
         status: 200,
       };
 
@@ -462,41 +514,44 @@ describe('tokenService - Axios Interceptors', () => {
       expect(result).toBe(response);
     });
 
-    it('does not retry auth endpoints on 401', async () => {
+    it("does not retry auth endpoints on 401", async () => {
       setupAxiosInterceptors();
 
-      const errorInterceptor = (mockedAxios.interceptors.response.use as any).mock.calls[0][1];
+      const errorInterceptor = (mockedAxios.interceptors.response.use as any)
+        .mock.calls[0][1];
 
       const error = {
         response: { status: 401 },
-        config: { url: '/api/token/refresh/' },
+        config: { url: "/api/token/refresh/" },
       };
 
       await expect(errorInterceptor(error)).rejects.toEqual(error);
       expect(mockedAxios.post).not.toHaveBeenCalled();
     });
 
-    it('retries request with new token on 401 after successful refresh', async () => {
+    it("retries request with new token on 401 after successful refresh", async () => {
       const expiredAccessToken = createJWT(-100);
       const newAccessToken = createJWT(3600);
+      const newRefreshToken = createJWT(7200);
       setStoredTokens(expiredAccessToken, createJWT(3600));
 
       mockedAxios.post.mockResolvedValueOnce({
-        data: { access: newAccessToken },
+        data: { access: newAccessToken, refresh: newRefreshToken },
       });
 
       mockedAxios.mockResolvedValueOnce({
-        data: { message: 'success after retry' },
+        data: { message: "success after retry" },
       });
 
       setupAxiosInterceptors();
 
-      const errorInterceptor = (mockedAxios.interceptors.response.use as any).mock.calls[0][1];
+      const errorInterceptor = (mockedAxios.interceptors.response.use as any)
+        .mock.calls[0][1];
 
       const error = {
         response: { status: 401 },
         config: {
-          url: '/api/profile/',
+          url: "/api/profile/",
           headers: {} as Record<string, string>,
           _retry: false,
         },
@@ -504,26 +559,29 @@ describe('tokenService - Axios Interceptors', () => {
 
       await errorInterceptor(error);
 
-      expect(error.config.headers.Authorization).toBe(`Bearer ${newAccessToken}`);
+      expect(error.config.headers.Authorization).toBe(
+        `Bearer ${newAccessToken}`,
+      );
       expect(mockedAxios).toHaveBeenCalledWith(error.config);
     });
 
-    it('calls logout handler when refresh fails on 401', async () => {
+    it("calls logout handler when refresh fails on 401", async () => {
       const logoutHandler = vi.fn();
       setLogoutHandler(logoutHandler);
 
       setStoredTokens(createJWT(-100), createJWT(3600));
 
-      mockedAxios.post.mockRejectedValueOnce(new Error('Refresh failed'));
+      mockedAxios.post.mockRejectedValueOnce(new Error("Refresh failed"));
 
       setupAxiosInterceptors();
 
-      const errorInterceptor = (mockedAxios.interceptors.response.use as any).mock.calls[0][1];
+      const errorInterceptor = (mockedAxios.interceptors.response.use as any)
+        .mock.calls[0][1];
 
       const error = {
         response: { status: 401 },
         config: {
-          url: '/api/profile/',
+          url: "/api/profile/",
           headers: {},
         },
       };
@@ -531,15 +589,18 @@ describe('tokenService - Axios Interceptors', () => {
       await expect(errorInterceptor(error)).rejects.toThrow();
 
       // Wait for async operations
-      await new Promise(resolve => setTimeout(resolve, 50));
+      await new Promise((resolve) => setTimeout(resolve, 50));
 
       expect(logoutHandler).toHaveBeenCalledTimes(1);
-      expect(toast.error).toHaveBeenCalledWith('You have been automatically logged out. Please log in again.', undefined);
+      expect(toast.error).toHaveBeenCalledWith(
+        "You have been automatically logged out. Please log in again.",
+        undefined,
+      );
     });
 
-    it('does not show multiple logout toasts for concurrent failures', async () => {
+    it("does not show multiple logout toasts for concurrent failures", async () => {
       // Wait for toast deduplication cache to clear from previous test
-      await new Promise(resolve => setTimeout(resolve, 3100));
+      await new Promise((resolve) => setTimeout(resolve, 3100));
 
       vi.clearAllMocks(); // Clear mock call counts after waiting
 
@@ -548,31 +609,32 @@ describe('tokenService - Axios Interceptors', () => {
 
       setStoredTokens(createJWT(-100), createJWT(3600));
 
-      mockedAxios.post.mockRejectedValue(new Error('Refresh failed'));
+      mockedAxios.post.mockRejectedValue(new Error("Refresh failed"));
 
       setupAxiosInterceptors();
 
-      const errorInterceptor = (mockedAxios.interceptors.response.use as any).mock.calls[0][1];
+      const errorInterceptor = (mockedAxios.interceptors.response.use as any)
+        .mock.calls[0][1];
 
       const errors = [
         {
           response: { status: 401 },
-          config: { url: '/api/profile/', headers: {} },
+          config: { url: "/api/profile/", headers: {} },
         },
         {
           response: { status: 401 },
-          config: { url: '/api/courses/', headers: {} },
+          config: { url: "/api/courses/", headers: {} },
         },
         {
           response: { status: 401 },
-          config: { url: '/api/assignments/', headers: {} },
+          config: { url: "/api/assignments/", headers: {} },
         },
       ];
 
       await Promise.allSettled(errors.map((error) => errorInterceptor(error)));
 
       // Wait for async operations
-      await new Promise(resolve => setTimeout(resolve, 50));
+      await new Promise((resolve) => setTimeout(resolve, 50));
 
       // Should only show toast once despite 3 failed requests (deduplication works)
       expect(toast.error).toHaveBeenCalledTimes(1);

--- a/backend/EduLite/EduLite/settings.py
+++ b/backend/EduLite/EduLite/settings.py
@@ -276,8 +276,12 @@ if ("test" in sys.argv or "mercury_test" in sys.argv) and DEBUG == True:
     ]
 
 SIMPLE_JWT = {
-    "ACCESS_TOKEN_LIFETIME": timedelta(minutes=5),  # Default is 5 minutes
-    "REFRESH_TOKEN_LIFETIME": timedelta(days=1),  # Default is 1 day
+    "ACCESS_TOKEN_LIFETIME": timedelta(
+        minutes=30
+    ),  # Reduced refresh frequency for better UX
+    "REFRESH_TOKEN_LIFETIME": timedelta(
+        days=7
+    ),  # Users stay logged in across sessions for a week
     "ROTATE_REFRESH_TOKENS": True,  # If True, a new refresh token is issued when you use a refresh token.
     "BLACKLIST_AFTER_ROTATION": True,  # If True, old refresh tokens are blacklisted after rotation. Requires an additional app for blacklisting.
     "UPDATE_LAST_LOGIN": False,  # Default is False. If True, updates the user's last_login field.
@@ -287,7 +291,7 @@ SIMPLE_JWT = {
     "AUDIENCE": None,  # Default
     "ISSUER": None,  # Default
     "JWK_URL": None,  # Default
-    "LEEWAY": 0,  # Default
+    "LEEWAY": 10,  # 10 seconds of clock-skew tolerance between client and server
     "AUTH_HEADER_TYPES": (
         "Bearer",
     ),  # Default is ('Bearer',). Defines the prefix for the Authorization header.

--- a/backend/EduLite/users/jwt_views.py
+++ b/backend/EduLite/users/jwt_views.py
@@ -20,8 +20,8 @@ from drf_spectacular.utils import (
     Authenticate with username and password to receive JWT access and refresh tokens.
 
     **Token Lifetimes:**
-    - Access token: 5 minutes
-    - Refresh token: 1 day
+    - Access token: 30 minutes
+    - Refresh token: 7 days
 
     Use the access token in the Authorization header for authenticated requests:
     `Authorization: Bearer <access_token>`
@@ -58,10 +58,10 @@ from drf_spectacular.utils import (
                 name="TokenPairResponse",
                 fields={
                     "access": serializers.CharField(
-                        help_text="JWT access token (expires in 5 minutes)"
+                        help_text="JWT access token (expires in 30 minutes)"
                     ),
                     "refresh": serializers.CharField(
-                        help_text="JWT refresh token (expires in 1 day)"
+                        help_text="JWT refresh token (expires in 7 days)"
                     ),
                 },
             ),
@@ -133,7 +133,7 @@ class CustomTokenObtainPairView(TokenObtainPairView):
     description="""
     Get a new access token using a valid refresh token.
 
-    When your access token expires (after 5 minutes), use this endpoint with your
+    When your access token expires (after 30 minutes), use this endpoint with your
     refresh token to get a new access token without re-authenticating.
 
     **Note:** If token rotation is enabled, you'll also receive a new refresh token.


### PR DESCRIPTION
# Fix: Unexpected logouts during save and other actions

Closes #222

## Problem

Users were getting force-logged out every ~10 minutes, especially when performing actions like saving slideshows or updating profiles. The logout appeared random and was triggered by whichever API call happened to coincide with the second token refresh cycle after login.

### Root cause

The backend is configured with `ROTATE_REFRESH_TOKENS = True` and `BLACKLIST_AFTER_ROTATION = True`. This means every call to `/api/token/refresh/` returns a **new** refresh token and **blacklists** the old one. But `refreshAccessToken()` in `tokenService.ts` only stored the new access token — the new refresh token was silently discarded.

```
T=0:00   Login    -> access=A1, refresh=R1 -> both stored
T=5:00   Refresh  -> server returns A2 + R2, blacklists R1
                  -> frontend stores A2, DISCARDS R2, still has R1
T=10:00  Refresh  -> frontend sends R1 (blacklisted) -> 401 -> forced logout
```

This was compounded by the access token lifetime being only 5 minutes, meaning refresh happened constantly.

## Changes

### Critical fix: store rotated refresh token
**`Frontend/EduLiteFrontend/src/services/tokenService.ts`**

`refreshAccessToken()` now stores both the new access and new refresh token from the server response. A guard (`if (newRefresh)`) ensures backward compatibility if rotation is ever disabled.

### Token lifetime improvements
**`backend/EduLite/EduLite/settings.py`**

| Setting | Before | After | Reason |
|---------|--------|-------|--------|
| `ACCESS_TOKEN_LIFETIME` | 5 min | 30 min | Reduces refresh frequency ~6x |
| `REFRESH_TOKEN_LIFETIME` | 1 day | 7 days | Users stay logged in across sessions |
| `LEEWAY` | 0 sec | 10 sec | Clock-skew tolerance between client/server |

### OpenAPI docs
**`backend/EduLite/users/jwt_views.py`**

Updated hardcoded lifetime references in `@extend_schema` decorators to match new settings.

### Frontend tests
**`Frontend/EduLiteFrontend/src/services/__tests__/tokenService.test.ts`**

- Replaced "successfully refreshes access token" with two tests:
  - **"successfully refreshes and stores both tokens when rotation is enabled"** — mocks server returning both tokens, asserts both are stored
  - **"preserves existing refresh token when server does not return one"** — ensures no regression if rotation is disabled
- Updated all other refresh mocks to include the `refresh` field, matching real server behavior

### Backend tests
**`backend/EduLite/EduLite/tests/test_JWTEndpoints.py`**

- `test_refresh_token_success` now asserts the rotated refresh token is present and different from the original (previously had a TODO comment acknowledging this was missing)
- Added `test_refresh_token_blacklisted_after_rotation` — uses a refresh token, then tries to reuse it, asserting the server returns 401

## Testing

- Frontend: 43/43 tests passing
- Backend: 9/9 JWT endpoint tests passing (including 2 new/updated rotation tests)
