### PR TITLE
course permissions configuration

### DIFF
--- a/backend/EduLite/EduLite/settings.py
+++ b/backend/EduLite/EduLite/settings.py
@@ -306,6 +306,11 @@ SIMPLE_JWT = {
 
 BLOCKED_EMAIL_DOMAINS = ["test.com"]  # For testing
 
+# Course Settings
+COURSE_CREATION_REQUIRES_TEACHER = (
+    True  # Set to False to allow any authenticated user to create courses
+)
+
 # CORS settings
 CORS_ALLOWED_ORIGINS = config(
     "CORS_ALLOWED_ORIGINS",

--- a/backend/EduLite/courses/permissions.py
+++ b/backend/EduLite/courses/permissions.py
@@ -1,6 +1,9 @@
 """Custom permissions for the courses app."""
 
+from django.conf import settings
 from rest_framework.permissions import BasePermission
+
+from .models import CourseMembership
 
 
 class IsTeacherUser(BasePermission):
@@ -18,3 +21,103 @@ class IsTeacherUser(BasePermission):
             return False
 
         return profile.occupation == "teacher"
+
+
+class CanCreateCourse(BasePermission):
+    """
+    Allow course creation based on the COURSE_CREATION_REQUIRES_TEACHER setting.
+
+    When True (default): only users with profile.occupation == "teacher" can create.
+    When False: any authenticated user can create.
+    """
+
+    message = "You do not have permission to create courses."
+
+    def has_permission(self, request, view) -> bool:
+        user = getattr(request, "user", None)
+        if not user or not user.is_authenticated:
+            return False
+
+        if not getattr(settings, "COURSE_CREATION_REQUIRES_TEACHER", True):
+            return True
+
+        profile = getattr(user, "profile", None)
+        if not profile:
+            return False
+
+        return profile.occupation == "teacher"
+
+
+class IsCourseTeacher(BasePermission):
+    """
+    Object-level permission: user must be a teacher in the course.
+
+    For views with a course pk in the URL, checks has_permission directly.
+    For detail views, checks has_object_permission on the course object.
+    """
+
+    message = "Only course teachers can perform this action."
+
+    def has_permission(self, request, view) -> bool:
+        user = getattr(request, "user", None)
+        if not user or not user.is_authenticated:
+            return False
+
+        course_pk = view.kwargs.get("pk")
+        if course_pk is not None:
+            return CourseMembership.objects.filter(
+                user=user,
+                course_id=course_pk,
+                role="teacher",
+                status="enrolled",
+            ).exists()
+
+        return True
+
+    def has_object_permission(self, request, view, obj) -> bool:
+        user = getattr(request, "user", None)
+        if not user or not user.is_authenticated:
+            return False
+
+        course = obj if hasattr(obj, "visibility") else getattr(obj, "course", obj)
+        return CourseMembership.objects.filter(
+            user=user,
+            course=course,
+            role="teacher",
+            status="enrolled",
+        ).exists()
+
+
+class IsCourseMember(BasePermission):
+    """
+    Object-level permission: user must be an enrolled member of the course.
+    """
+
+    message = "You must be a course member to perform this action."
+
+    def has_permission(self, request, view) -> bool:
+        user = getattr(request, "user", None)
+        if not user or not user.is_authenticated:
+            return False
+
+        course_pk = view.kwargs.get("pk")
+        if course_pk is not None:
+            return CourseMembership.objects.filter(
+                user=user,
+                course_id=course_pk,
+                status="enrolled",
+            ).exists()
+
+        return True
+
+    def has_object_permission(self, request, view, obj) -> bool:
+        user = getattr(request, "user", None)
+        if not user or not user.is_authenticated:
+            return False
+
+        course = obj if hasattr(obj, "visibility") else getattr(obj, "course", obj)
+        return CourseMembership.objects.filter(
+            user=user,
+            course=course,
+            status="enrolled",
+        ).exists()

--- a/backend/EduLite/courses/tests/test_permissions.py
+++ b/backend/EduLite/courses/tests/test_permissions.py
@@ -1,0 +1,199 @@
+"""Tests for courses app custom permissions."""
+
+from typing import Optional
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase, APIRequestFactory
+
+from courses.models import Course, CourseMembership
+from courses.permissions import CanCreateCourse, IsCourseTeacher, IsCourseMember
+
+User = get_user_model()
+
+
+class CanCreateCoursePermissionTests(APITestCase):
+    """Test the CanCreateCourse permission with setting toggle."""
+
+    def setUp(self):
+        self.url = reverse("course-create")
+
+    def _create_user(self, username: str, occupation: Optional[str] = None):
+        user = User.objects.create_user(username=username, password="test-pass-123")
+        if occupation is not None:
+            profile = user.profile
+            profile.occupation = occupation
+            profile.save()
+        return user
+
+    @override_settings(COURSE_CREATION_REQUIRES_TEACHER=True)
+    def test_teacher_can_create_when_setting_true(self):
+        teacher = self._create_user("teacher1", "teacher")
+        self.client.force_authenticate(user=teacher)
+        response = self.client.post(self.url, {"title": "Test Course"}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    @override_settings(COURSE_CREATION_REQUIRES_TEACHER=True)
+    def test_non_teacher_denied_when_setting_true(self):
+        student = self._create_user("student1", "student")
+        self.client.force_authenticate(user=student)
+        response = self.client.post(self.url, {"title": "Test Course"}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @override_settings(COURSE_CREATION_REQUIRES_TEACHER=False)
+    def test_any_user_can_create_when_setting_false(self):
+        student = self._create_user("student2", "student")
+        self.client.force_authenticate(user=student)
+        response = self.client.post(self.url, {"title": "Test Course"}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    @override_settings(COURSE_CREATION_REQUIRES_TEACHER=False)
+    def test_unauthenticated_denied_even_when_setting_false(self):
+        response = self.client.post(self.url, {"title": "Test Course"}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    @override_settings(COURSE_CREATION_REQUIRES_TEACHER=True)
+    def test_user_without_occupation_denied_when_setting_true(self):
+        """User with no occupation set should be denied when teacher is required."""
+        user = self._create_user("noocc")
+        self.client.force_authenticate(user=user)
+        response = self.client.post(self.url, {"title": "Test Course"}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class IsCourseTeacherPermissionTests(TestCase):
+    """Test the IsCourseTeacher permission class."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.teacher = User.objects.create_user(
+            username="teacher", password="test-pass-123"
+        )
+        cls.student = User.objects.create_user(
+            username="student", password="test-pass-123"
+        )
+        cls.outsider = User.objects.create_user(
+            username="outsider", password="test-pass-123"
+        )
+        cls.course = Course.objects.create(title="Test Course")
+        CourseMembership.objects.create(
+            user=cls.teacher, course=cls.course, role="teacher", status="enrolled"
+        )
+        CourseMembership.objects.create(
+            user=cls.student, course=cls.course, role="student", status="enrolled"
+        )
+
+    def _make_request(self, user):
+        factory = APIRequestFactory()
+        request = factory.get("/fake/")
+        request.user = user
+        return request
+
+    def _make_view(self, pk=None):
+        class FakeView:
+            kwargs = {}
+
+        view = FakeView()
+        if pk is not None:
+            view.kwargs["pk"] = pk
+        return view
+
+    def test_teacher_has_permission(self):
+        perm = IsCourseTeacher()
+        request = self._make_request(self.teacher)
+        view = self._make_view(pk=self.course.pk)
+        self.assertTrue(perm.has_permission(request, view))
+
+    def test_student_denied_permission(self):
+        perm = IsCourseTeacher()
+        request = self._make_request(self.student)
+        view = self._make_view(pk=self.course.pk)
+        self.assertFalse(perm.has_permission(request, view))
+
+    def test_outsider_denied_permission(self):
+        perm = IsCourseTeacher()
+        request = self._make_request(self.outsider)
+        view = self._make_view(pk=self.course.pk)
+        self.assertFalse(perm.has_permission(request, view))
+
+    def test_teacher_has_object_permission(self):
+        perm = IsCourseTeacher()
+        request = self._make_request(self.teacher)
+        view = self._make_view()
+        self.assertTrue(perm.has_object_permission(request, view, self.course))
+
+    def test_student_denied_object_permission(self):
+        perm = IsCourseTeacher()
+        request = self._make_request(self.student)
+        view = self._make_view()
+        self.assertFalse(perm.has_object_permission(request, view, self.course))
+
+
+class IsCourseMemberPermissionTests(TestCase):
+    """Test the IsCourseMember permission class."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.member = User.objects.create_user(
+            username="member", password="test-pass-123"
+        )
+        cls.pending = User.objects.create_user(
+            username="pending", password="test-pass-123"
+        )
+        cls.outsider = User.objects.create_user(
+            username="outsider", password="test-pass-123"
+        )
+        cls.course = Course.objects.create(title="Test Course")
+        CourseMembership.objects.create(
+            user=cls.member, course=cls.course, role="student", status="enrolled"
+        )
+        CourseMembership.objects.create(
+            user=cls.pending, course=cls.course, role="student", status="pending"
+        )
+
+    def _make_request(self, user):
+        factory = APIRequestFactory()
+        request = factory.get("/fake/")
+        request.user = user
+        return request
+
+    def _make_view(self, pk=None):
+        class FakeView:
+            kwargs = {}
+
+        view = FakeView()
+        if pk is not None:
+            view.kwargs["pk"] = pk
+        return view
+
+    def test_enrolled_member_has_permission(self):
+        perm = IsCourseMember()
+        request = self._make_request(self.member)
+        view = self._make_view(pk=self.course.pk)
+        self.assertTrue(perm.has_permission(request, view))
+
+    def test_pending_member_denied_permission(self):
+        perm = IsCourseMember()
+        request = self._make_request(self.pending)
+        view = self._make_view(pk=self.course.pk)
+        self.assertFalse(perm.has_permission(request, view))
+
+    def test_outsider_denied_permission(self):
+        perm = IsCourseMember()
+        request = self._make_request(self.outsider)
+        view = self._make_view(pk=self.course.pk)
+        self.assertFalse(perm.has_permission(request, view))
+
+    def test_enrolled_member_has_object_permission(self):
+        perm = IsCourseMember()
+        request = self._make_request(self.member)
+        view = self._make_view()
+        self.assertTrue(perm.has_object_permission(request, view, self.course))
+
+    def test_pending_member_denied_object_permission(self):
+        perm = IsCourseMember()
+        request = self._make_request(self.pending)
+        view = self._make_view()
+        self.assertFalse(perm.has_object_permission(request, view, self.course))

--- a/backend/EduLite/courses/views.py
+++ b/backend/EduLite/courses/views.py
@@ -12,6 +12,7 @@ from drf_spectacular.utils import (
 )
 
 from .models import CourseMembership
+from .permissions import CanCreateCourse
 from .serializers import CourseSerializer
 
 User = get_user_model()
@@ -23,7 +24,7 @@ class CourseCreateView(generics.CreateAPIView):
     """Create a course for the authenticated user."""
 
     serializer_class = CourseSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [CanCreateCourse]
 
     @extend_schema(
         summary="Create a course",


### PR DESCRIPTION
## Description

Add configurable course creation permissions and reusable object-level permission classes for the courses API.

- **`COURSE_CREATION_REQUIRES_TEACHER`** setting (default `True`) — when enabled, only users with `profile.occupation == "teacher"` can create courses; when `False`, any authenticated user can.
- **`CanCreateCourse`** permission — gates `CourseCreateView` based on the above setting.
- **`IsCourseTeacher`** permission — object-level check that the user holds a teacher membership (`role="teacher"`, `status="enrolled"`) in the course. Supports both URL-based `pk` lookup and `has_object_permission`.
- **`IsCourseMember`** permission — object-level check that the user has any enrolled membership in the course.
- Updated `CourseCreateView` to use `CanCreateCourse` instead of `IsAuthenticated`.
- Updated existing course creation test to account for the new default, added 15 new permission unit tests.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Documentation update

## Testing
- [x] `python manage.py test courses` — 20 tests pass
- [x] New `test_permissions.py` covers `CanCreateCourse`, `IsCourseTeacher`, `IsCourseMember`
- [x] Updated `test_api_course_create.py` to use `override_settings` for the permissive mode test

## Related Issues
Closes #224
