### PR TITLE
implement serializers for courses

### DIFF
--- a/backend/EduLite/courses/pagination.py
+++ b/backend/EduLite/courses/pagination.py
@@ -1,0 +1,35 @@
+"""Pagination classes for the courses app."""
+
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.response import Response
+
+
+class CoursePagination(PageNumberPagination):
+    """
+    Standard pagination for course listings.
+    Optimized for browsing courses in discovery and user libraries.
+    """
+
+    page_size = 20
+    page_size_query_param = "page_size"
+    max_page_size = 100
+
+    def paginate_queryset(self, queryset, request, view=None):
+        """Override to store the actual page size being used."""
+        self.request = request
+        # Store the actual page size for this request
+        self._current_page_size = self.get_page_size(request)
+        return super().paginate_queryset(queryset, request, view)
+
+    def get_paginated_response(self, data):
+        return Response(
+            {
+                "next": self.get_next_link(),
+                "previous": self.get_previous_link(),
+                "count": self.page.paginator.count,
+                "total_pages": self.page.paginator.num_pages,
+                "current_page": self.page.number,
+                "results": data,
+                "page_size": getattr(self, "_current_page_size", self.page_size),
+            }
+        )

--- a/backend/EduLite/courses/tests/serializers/test_CourseDetailSerializer.py
+++ b/backend/EduLite/courses/tests/serializers/test_CourseDetailSerializer.py
@@ -1,0 +1,155 @@
+from datetime import datetime
+
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase, RequestFactory
+
+from chat.models import ChatRoom
+from ...models import Course, CourseMembership, CourseModule
+from ...serializers import CourseDetailSerializer
+
+User = get_user_model()
+
+
+class CourseDetailSerializerTest(TestCase):
+    """Test suite for CourseDetailSerializer."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.factory = RequestFactory()
+        cls.teacher = User.objects.create_user(
+            username="teacher1", password="pass12345", email="teacher1@example.com"
+        )
+        cls.student = User.objects.create_user(
+            username="student1", password="pass12345", email="student1@example.com"
+        )
+        cls.outsider = User.objects.create_user(
+            username="outsider", password="pass12345", email="outsider@example.com"
+        )
+        cls.course = Course.objects.create(
+            title="Detail Test Course",
+            outline="A course for detail testing",
+            language="en",
+            country="US",
+            subject="physics",
+            visibility="public",
+            start_date=datetime(2025, 9, 1, 8, 0, 0),
+            end_date=datetime(2025, 12, 15, 20, 0, 0),
+            is_active=True,
+            allow_join_requests=True,
+        )
+        cls.teacher_membership = CourseMembership.objects.create(
+            user=cls.teacher, course=cls.course, role="teacher", status="enrolled"
+        )
+        cls.student_membership = CourseMembership.objects.create(
+            user=cls.student, course=cls.course, role="student", status="enrolled"
+        )
+        # Create a module using ChatRoom as the content object
+        cls.chatroom = ChatRoom.objects.create(name="Test Room", creator=cls.teacher)
+        cls.module = CourseModule.objects.create(
+            course=cls.course,
+            title="Chat Module",
+            order=0,
+            content_type=ContentType.objects.get_for_model(ChatRoom),
+            object_id=cls.chatroom.pk,
+        )
+
+    def _get_context(self, user=None):
+        """Helper to build serializer context with a request."""
+        request = self.factory.get("/")
+        if user:
+            request.user = user
+        else:
+            from django.contrib.auth.models import AnonymousUser
+
+            request.user = AnonymousUser()
+        return {"request": request}
+
+    def test_detail_serializer_contains_expected_fields(self):
+        """Test that detail serializer includes all expected fields."""
+        serializer = CourseDetailSerializer(
+            self.course, context=self._get_context(self.teacher)
+        )
+        expected_fields = {
+            "id",
+            "title",
+            "outline",
+            "language",
+            "country",
+            "subject",
+            "visibility",
+            "start_date",
+            "end_date",
+            "duration_time",
+            "allow_join_requests",
+            "is_active",
+            "member_count",
+            "user_role",
+            "members",
+            "modules",
+        }
+        self.assertEqual(set(serializer.data.keys()), expected_fields)
+
+    def test_detail_serializer_nested_members(self):
+        """Test that members are nested in the output."""
+        serializer = CourseDetailSerializer(
+            self.course, context=self._get_context(self.teacher)
+        )
+        members = serializer.data["members"]
+        self.assertEqual(len(members), 2)
+        usernames = {m["user_name"] for m in members}
+        self.assertEqual(usernames, {"teacher1", "student1"})
+
+    def test_detail_serializer_nested_modules(self):
+        """Test that modules are nested in the output."""
+        serializer = CourseDetailSerializer(
+            self.course, context=self._get_context(self.teacher)
+        )
+        modules = serializer.data["modules"]
+        self.assertEqual(len(modules), 1)
+        self.assertEqual(modules[0]["title"], "Chat Module")
+        self.assertEqual(modules[0]["order"], 0)
+
+    def test_detail_serializer_member_count(self):
+        """Test that member_count matches actual memberships."""
+        serializer = CourseDetailSerializer(
+            self.course, context=self._get_context(self.teacher)
+        )
+        self.assertEqual(serializer.data["member_count"], 2)
+
+    def test_detail_serializer_duration_time(self):
+        """Test that duration_time is computed correctly."""
+        serializer = CourseDetailSerializer(
+            self.course, context=self._get_context(self.teacher)
+        )
+        # Sep 1 08:00 to Dec 15 20:00
+        expected_minutes = (
+            self.course.end_date - self.course.start_date
+        ).total_seconds() // 60
+        self.assertEqual(serializer.data["duration_time"], expected_minutes)
+
+    def test_detail_serializer_user_role_teacher(self):
+        """Test that user_role returns 'teacher' for a teacher member."""
+        serializer = CourseDetailSerializer(
+            self.course, context=self._get_context(self.teacher)
+        )
+        self.assertEqual(serializer.data["user_role"], "teacher")
+
+    def test_detail_serializer_user_role_student(self):
+        """Test that user_role returns 'student' for a student member."""
+        serializer = CourseDetailSerializer(
+            self.course, context=self._get_context(self.student)
+        )
+        self.assertEqual(serializer.data["user_role"], "student")
+
+    def test_detail_serializer_user_role_null_for_non_member(self):
+        """Test that user_role returns null for a user not in the course."""
+        serializer = CourseDetailSerializer(
+            self.course, context=self._get_context(self.outsider)
+        )
+        self.assertIsNone(serializer.data["user_role"])
+
+    def test_detail_serializer_user_role_null_for_anonymous(self):
+        """Test that user_role returns null for an anonymous user."""
+        serializer = CourseDetailSerializer(self.course, context=self._get_context())
+        self.assertIsNone(serializer.data["user_role"])

--- a/backend/EduLite/courses/tests/serializers/test_CourseListSerializer.py
+++ b/backend/EduLite/courses/tests/serializers/test_CourseListSerializer.py
@@ -1,0 +1,92 @@
+from datetime import datetime
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from ...models import Course, CourseMembership
+from ...serializers import CourseListSerializer
+
+User = get_user_model()
+
+
+class CourseListSerializerTest(TestCase):
+    """Test suite for CourseListSerializer."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user1 = User.objects.create_user(
+            username="teacher1", password="pass12345", email="teacher1@example.com"
+        )
+        cls.user2 = User.objects.create_user(
+            username="student1", password="pass12345", email="student1@example.com"
+        )
+        cls.course = Course.objects.create(
+            title="Test Course",
+            outline="A test course outline",
+            language="en",
+            country="US",
+            subject="physics",
+            visibility="public",
+            start_date=datetime(2025, 9, 1, 8, 0, 0),
+            end_date=datetime(2025, 12, 15, 20, 0, 0),
+            is_active=True,
+        )
+        CourseMembership.objects.create(
+            user=cls.user1, course=cls.course, role="teacher", status="enrolled"
+        )
+        CourseMembership.objects.create(
+            user=cls.user2, course=cls.course, role="student", status="enrolled"
+        )
+
+    def test_list_serializer_contains_expected_fields(self):
+        """Test that list serializer includes exactly the expected fields."""
+        serializer = CourseListSerializer(self.course)
+        expected_fields = {
+            "id",
+            "title",
+            "outline",
+            "visibility",
+            "subject",
+            "language",
+            "country",
+            "is_active",
+            "member_count",
+            "start_date",
+            "end_date",
+        }
+        self.assertEqual(set(serializer.data.keys()), expected_fields)
+
+    def test_list_serializer_member_count(self):
+        """Test that member_count returns the correct number of memberships."""
+        serializer = CourseListSerializer(self.course)
+        self.assertEqual(serializer.data["member_count"], 2)
+
+    def test_list_serializer_member_count_with_annotation(self):
+        """Test that member_count reads from annotation when available."""
+        from django.db.models import Count
+
+        qs = Course.objects.annotate(member_count=Count("memberships"))
+        course = qs.get(pk=self.course.pk)
+        serializer = CourseListSerializer(course)
+        self.assertEqual(serializer.data["member_count"], 2)
+
+    def test_list_serializer_does_not_include_nested_data(self):
+        """Test that list serializer does not include members, modules, or user_role."""
+        serializer = CourseListSerializer(self.course)
+        self.assertNotIn("members", serializer.data)
+        self.assertNotIn("modules", serializer.data)
+        self.assertNotIn("user_role", serializer.data)
+        self.assertNotIn("duration_time", serializer.data)
+        self.assertNotIn("allow_join_requests", serializer.data)
+
+    def test_list_serializer_field_values(self):
+        """Test that serialized field values match the model."""
+        serializer = CourseListSerializer(self.course)
+        data = serializer.data
+        self.assertEqual(data["title"], "Test Course")
+        self.assertEqual(data["outline"], "A test course outline")
+        self.assertEqual(data["visibility"], "public")
+        self.assertEqual(data["subject"], "physics")
+        self.assertEqual(data["language"], "en")
+        self.assertEqual(data["country"], "US")
+        self.assertTrue(data["is_active"])

--- a/backend/EduLite/courses/tests/test_pagination.py
+++ b/backend/EduLite/courses/tests/test_pagination.py
@@ -1,0 +1,89 @@
+from datetime import datetime
+
+from django.test import TestCase, RequestFactory
+from rest_framework.request import Request
+
+from ..models import Course
+from ..pagination import CoursePagination
+
+
+class CoursePaginationTest(TestCase):
+    """Test suite for CoursePagination."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.factory = RequestFactory()
+        # Create 25 courses for pagination testing
+        courses = []
+        for i in range(25):
+            courses.append(
+                Course(
+                    title=f"Course {i}",
+                    outline=f"Outline for course {i}",
+                    visibility="public",
+                    start_date=datetime(2025, 1, 1),
+                    end_date=datetime(2025, 12, 31),
+                )
+            )
+        Course.objects.bulk_create(courses)
+
+    def _paginate(self, query_params=""):
+        """Helper to paginate the full Course queryset with given query params."""
+        paginator = CoursePagination()
+        django_request = self.factory.get(f"/?{query_params}" if query_params else "/")
+        request = Request(django_request)
+        queryset = Course.objects.all().order_by("id")
+        page = paginator.paginate_queryset(queryset, request)
+        response = paginator.get_paginated_response(
+            [{"id": c.id, "title": c.title} for c in page]
+        )
+        return response.data
+
+    def test_pagination_response_structure(self):
+        """Test that paginated response contains all expected keys."""
+        data = self._paginate()
+        expected_keys = {
+            "next",
+            "previous",
+            "count",
+            "total_pages",
+            "current_page",
+            "results",
+            "page_size",
+        }
+        self.assertEqual(set(data.keys()), expected_keys)
+
+    def test_pagination_default_page_size(self):
+        """Test that default page size is 20."""
+        data = self._paginate()
+        self.assertEqual(data["page_size"], 20)
+        self.assertEqual(len(data["results"]), 20)
+        self.assertEqual(data["count"], 25)
+        self.assertEqual(data["total_pages"], 2)
+        self.assertEqual(data["current_page"], 1)
+        self.assertIsNotNone(data["next"])
+        self.assertIsNone(data["previous"])
+
+    def test_pagination_custom_page_size(self):
+        """Test that custom page_size query parameter works."""
+        data = self._paginate("page_size=10")
+        self.assertEqual(data["page_size"], 10)
+        self.assertEqual(len(data["results"]), 10)
+        self.assertEqual(data["count"], 25)
+        self.assertEqual(data["total_pages"], 3)
+
+    def test_pagination_max_page_size(self):
+        """Test that page_size is capped at max_page_size (100)."""
+        data = self._paginate("page_size=200")
+        self.assertEqual(data["page_size"], 100)
+        # All 25 courses fit in one page when max is 100
+        self.assertEqual(len(data["results"]), 25)
+        self.assertEqual(data["total_pages"], 1)
+
+    def test_pagination_second_page(self):
+        """Test navigating to second page."""
+        data = self._paginate("page=2")
+        self.assertEqual(data["current_page"], 2)
+        self.assertEqual(len(data["results"]), 5)  # 25 - 20 = 5 remaining
+        self.assertIsNone(data["next"])
+        self.assertIsNotNone(data["previous"])


### PR DESCRIPTION
## Description
# Courses API: List/Detail serializers + pagination

Add configurable course creation permissions and reusable object-level permission classes for the courses API.
Closes #225

- **`COURSE_CREATION_REQUIRES_TEACHER`** setting (default `True`) — when enabled, only users with `profile.occupation == "teacher"` can create courses; when `False`, any authenticated user can.
- **`CanCreateCourse`** permission — gates `CourseCreateView` based on the above setting.
- **`IsCourseTeacher`** permission — object-level check that the user holds a teacher membership (`role="teacher"`, `status="enrolled"`) in the course. Supports both URL-based `pk` lookup and `has_object_permission`.
- **`IsCourseMember`** permission — object-level check that the user has any enrolled membership in the course.
- Updated `CourseCreateView` to use `CanCreateCourse` instead of `IsAuthenticated`.
- Updated existing course creation test to account for the new default, added 15 new permission unit tests.
## Problem

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Documentation update
The courses app had a single `CourseSerializer` used only for creation. There was no lightweight serializer for listing courses, no detail serializer with nested membership/module data, and no pagination class. This made it impossible to build efficient list and detail views.

## Changes

### New: `CourseListSerializer`
**`backend/EduLite/courses/serializers.py`**

Lightweight serializer for listing courses. Returns only metadata — no nested relations.

Fields: `id`, `title`, `outline`, `visibility`, `subject`, `language`, `country`, `is_active`, `member_count`, `start_date`, `end_date`

`member_count` reads from a queryset annotation if available, otherwise falls back to `obj.memberships.count()`.

### New: `CourseDetailSerializer`
**`backend/EduLite/courses/serializers.py`**

Full serializer for course detail views. Includes everything from the creation serializer plus:

- `members` — nested list of `CourseMembershipSerializer` (read-only)
- `modules` — nested list of `CourseModuleSerializer` (read-only)
- `member_count` — same annotation-aware count as the list serializer
- `user_role` — returns the requesting user's role in the course (`"teacher"`, `"student"`, `"assistant"`), or `null` if not a member

### New: `CoursePagination`
**`backend/EduLite/courses/pagination.py`**

Follows the established `SlideshowPagination` pattern:
- Default page size: 20
- Configurable via `?page_size=` query param
- Max page size: 100
- Response includes: `next`, `previous`, `count`, `total_pages`, `current_page`, `page_size`, `results`

### New tests

| File | Tests | Covers |
|------|-------|--------|
| `tests/serializers/test_CourseListSerializer.py` | 5 | Field shape, member_count (direct + annotated), no nested data, field values |
| `tests/serializers/test_CourseDetailSerializer.py` | 9 | Field shape, nested members, nested modules, member_count, duration_time, user_role for teacher/student/non-member/anonymous |
| `tests/test_pagination.py` | 5 | Response structure, default page size, custom page size, max cap, second page navigation |

## What's NOT changed

- Existing `CourseSerializer` — untouched, still used for creation in `CourseCreateView`
- `CourseMembershipSerializer`, `CourseModuleSerializer`, `CourseChatRoomSerializer` — untouched
- No new views or URL patterns (those are a separate issue)

## Testing
- [x] `python manage.py test courses` — 20 tests pass
- [x] New `test_permissions.py` covers `CanCreateCourse`, `IsCourseTeacher`, `IsCourseMember`
- [x] Updated `test_api_course_create.py` to use `override_settings` for the permissive mode test

## Related Issues
Closes #224
All 61 courses tests pass, including the 19 new ones:

```
Ran 61 tests in 0.226s
OK
```
