### PR TITLE
 Courses API: Module CRUD endpoints + standards compliance

### DIFF
--- a/backend/EduLite/courses/tests/test_api_modules.py
+++ b/backend/EduLite/courses/tests/test_api_modules.py
@@ -1,0 +1,247 @@
+"""Tests for the course module CRUD API endpoints."""
+
+from datetime import datetime
+from typing import Optional
+
+from chat.models import ChatRoom
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from courses.models import Course, CourseMembership, CourseModule
+
+
+class CourseModuleAPITests(APITestCase):
+    """Validate course module list/create/detail/update/delete behaviour."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user_model = get_user_model()
+
+        # Create users
+        cls.teacher = cls._make_user("teacher_user", "teacher")
+        cls.student = cls._make_user("student_user", "student")
+        cls.outsider = cls._make_user("outsider_user", "student")
+
+        # Create course
+        cls.course = Course.objects.create(
+            title="Test Course",
+            outline="A course for testing modules.",
+            language="en",
+            country="US",
+            subject="physics",
+            visibility="private",
+            start_date=datetime(2025, 1, 1),
+            end_date=datetime(2025, 12, 31),
+        )
+
+        # Enroll teacher and student
+        CourseMembership.objects.create(
+            course=cls.course, user=cls.teacher, role="teacher", status="enrolled"
+        )
+        CourseMembership.objects.create(
+            course=cls.course, user=cls.student, role="student", status="enrolled"
+        )
+
+        # Content object for modules
+        cls.chatroom = ChatRoom.objects.create(
+            name="test_chatroom", room_type="ONE_TO_ONE"
+        )
+        cls.chatroom2 = ChatRoom.objects.create(
+            name="test_chatroom2", room_type="ONE_TO_ONE"
+        )
+        cls.chatroom_ct = ContentType.objects.get_for_model(ChatRoom)
+
+        # Pre-existing modules
+        cls.module1 = CourseModule.objects.create(
+            course=cls.course,
+            title="Module A",
+            order=1,
+            content_type=cls.chatroom_ct,
+            object_id=cls.chatroom.id,
+        )
+        cls.module2 = CourseModule.objects.create(
+            course=cls.course,
+            title="Module B",
+            order=2,
+            content_type=cls.chatroom_ct,
+            object_id=cls.chatroom2.id,
+        )
+
+    @classmethod
+    def _make_user(cls, username: str, occupation: Optional[str] = None):
+        user = cls.user_model.objects.create_user(
+            username=username, password="test-pass-123"
+        )
+        if occupation is not None:
+            profile = user.profile
+            profile.occupation = occupation
+            profile.save()
+        return user
+
+    def _list_url(self):
+        return reverse("course-module-list-create", kwargs={"pk": self.course.pk})
+
+    def _detail_url(self, module_id):
+        return reverse(
+            "course-module-detail",
+            kwargs={"pk": self.course.pk, "module_id": module_id},
+        )
+
+    # --- List (GET) ---
+
+    def test_list_modules_as_member(self):
+        """Enrolled members can list modules, ordered by order field."""
+        self.client.force_authenticate(user=self.student)
+        response = self.client.get(self._list_url())
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+        self.assertEqual(response.data[0]["title"], "Module A")
+        self.assertEqual(response.data[1]["title"], "Module B")
+
+    def test_list_modules_as_non_member(self):
+        """Non-members are denied access to module listing."""
+        self.client.force_authenticate(user=self.outsider)
+        response = self.client.get(self._list_url())
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_list_modules_unauthenticated(self):
+        """Unauthenticated clients are rejected."""
+        response = self.client.get(self._list_url())
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    # --- Create (POST) ---
+
+    def test_create_module_as_teacher(self):
+        """Teachers can create modules in their course."""
+        self.client.force_authenticate(user=self.teacher)
+        payload = {
+            "title": "New Module",
+            "order": 3,
+            "content_type": "chat.chatroom",
+            "object_id": self.chatroom.id,
+        }
+
+        response = self.client.post(self._list_url(), payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["title"], "New Module")
+        self.assertEqual(response.data["order"], 3)
+        self.assertEqual(response.data["course"], self.course.pk)
+        self.assertTrue(
+            CourseModule.objects.filter(course=self.course, title="New Module").exists()
+        )
+
+    def test_create_module_as_student(self):
+        """Students cannot create modules."""
+        self.client.force_authenticate(user=self.student)
+        payload = {
+            "title": "Sneaky Module",
+            "order": 3,
+            "content_type": "chat.chatroom",
+            "object_id": self.chatroom.id,
+        }
+
+        response = self.client.post(self._list_url(), payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_create_module_invalid_content_type(self):
+        """Invalid content_type returns 400."""
+        self.client.force_authenticate(user=self.teacher)
+        payload = {
+            "title": "Bad Module",
+            "order": 3,
+            "content_type": "invalid.model",
+            "object_id": self.chatroom.id,
+        }
+
+        response = self.client.post(self._list_url(), payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("content_type", response.data)
+
+    # --- Retrieve (GET detail) ---
+
+    def test_retrieve_module_as_member(self):
+        """Enrolled members can retrieve a single module."""
+        self.client.force_authenticate(user=self.student)
+        response = self.client.get(self._detail_url(self.module1.pk))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["title"], "Module A")
+        self.assertEqual(response.data["id"], self.module1.pk)
+
+    def test_retrieve_module_as_non_member(self):
+        """Non-members cannot retrieve a module."""
+        self.client.force_authenticate(user=self.outsider)
+        response = self.client.get(self._detail_url(self.module1.pk))
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_retrieve_module_not_found(self):
+        """Requesting a non-existent module returns 404."""
+        self.client.force_authenticate(user=self.student)
+        response = self.client.get(self._detail_url(99999))
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    # --- Update (PATCH) ---
+
+    def test_update_module_as_teacher(self):
+        """Teachers can partially update a module."""
+        self.client.force_authenticate(user=self.teacher)
+        payload = {"title": "Updated Module A", "order": 10}
+
+        response = self.client.patch(
+            self._detail_url(self.module1.pk), payload, format="json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["title"], "Updated Module A")
+        self.assertEqual(response.data["order"], 10)
+
+    def test_update_module_as_student(self):
+        """Students cannot update modules."""
+        self.client.force_authenticate(user=self.student)
+        payload = {"title": "Hacked Title"}
+
+        response = self.client.patch(
+            self._detail_url(self.module1.pk), payload, format="json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    # --- Delete (DELETE) ---
+
+    def test_delete_module_as_teacher(self):
+        """Teachers can delete a module."""
+        self.client.force_authenticate(user=self.teacher)
+
+        # Create a throwaway module to delete
+        module = CourseModule.objects.create(
+            course=self.course,
+            title="To Delete",
+            order=99,
+            content_type=self.chatroom_ct,
+            object_id=self.chatroom.id,
+        )
+
+        response = self.client.delete(self._detail_url(module.pk))
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(CourseModule.objects.filter(pk=module.pk).exists())
+
+    def test_delete_module_as_student(self):
+        """Students cannot delete modules."""
+        self.client.force_authenticate(user=self.student)
+
+        response = self.client.delete(self._detail_url(self.module1.pk))
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertTrue(CourseModule.objects.filter(pk=self.module1.pk).exists())

--- a/backend/EduLite/courses/urls.py
+++ b/backend/EduLite/courses/urls.py
@@ -1,7 +1,17 @@
 from django.urls import path
 
-from .views import CourseCreateView
+from .views import CourseCreateView, CourseModuleDetailView, CourseModuleListCreateView
 
 urlpatterns = [
     path("courses/", CourseCreateView.as_view(), name="course-create"),
+    path(
+        "courses/<int:pk>/modules/",
+        CourseModuleListCreateView.as_view(),
+        name="course-module-list-create",
+    ),
+    path(
+        "courses/<int:pk>/modules/<int:module_id>/",
+        CourseModuleDetailView.as_view(),
+        name="course-module-detail",
+    ),
 ]

--- a/backend/EduLite/courses/views.py
+++ b/backend/EduLite/courses/views.py
@@ -1,42 +1,57 @@
 import logging
-from typing import Any, cast
 
 from django.contrib.auth import get_user_model
 from django.db import transaction
-from rest_framework import exceptions, generics, permissions, serializers
+from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import (
-    extend_schema,
     OpenApiExample,
     OpenApiResponse,
+    extend_schema,
     inline_serializer,
 )
+from rest_framework import exceptions, permissions, serializers, status
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
-from .models import CourseMembership
-from .permissions import CanCreateCourse
-from .serializers import CourseSerializer
+from .models import Course, CourseMembership, CourseModule
+from .permissions import CanCreateCourse, IsCourseMember, IsCourseTeacher
+from .serializers import CourseModuleSerializer, CourseSerializer
 
 User = get_user_model()
 
 logger = logging.getLogger(__name__)
 
 
-class CourseCreateView(generics.CreateAPIView):
+class CoursesAppBaseAPIView(APIView):
+    """Base API view for the courses app."""
+
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get_serializer_context(self):
+        """Include request context for serializers."""
+        return {"request": self.request}
+
+
+# --- Course CRUD Operations ---
+
+
+class CourseCreateView(CoursesAppBaseAPIView):
     """Create a course for the authenticated user."""
 
-    serializer_class = CourseSerializer
     permission_classes = [CanCreateCourse]
 
     @extend_schema(
         summary="Create a course",
         description=(
-            "Create a new course. Any authenticated user can create a course and the creator is "
-            "automatically added to the course as a teacher membership."
+            "Create a new course. The creator is automatically added "
+            "as a teacher membership."
         ),
         tags=["Courses"],
         request=CourseSerializer,
         responses={
             201: OpenApiResponse(
-                description="Course successfully created.", response=CourseSerializer
+                description="Course successfully created.",
+                response=CourseSerializer,
             ),
             400: OpenApiResponse(
                 description="Validation error.",
@@ -53,6 +68,8 @@ class CourseCreateView(generics.CreateAPIView):
                     },
                 ),
             ),
+            401: OpenApiResponse(description="Authentication required."),
+            403: OpenApiResponse(description="Permission denied."),
         },
         examples=[
             OpenApiExample(
@@ -73,37 +90,247 @@ class CourseCreateView(generics.CreateAPIView):
             ),
         ],
     )
+    @transaction.atomic
     def post(self, request, *args, **kwargs):
         logger.debug("Course creation requested by user %s", request.user)
-        return super().post(request, *args, **kwargs)
 
-    @transaction.atomic
-    def perform_create(self, serializer: serializers.BaseSerializer[Any]) -> None:
-        """Persist the course and link the creator as a teacher."""
+        serializer = CourseSerializer(
+            data=request.data, context=self.get_serializer_context()
+        )
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-        course_serializer = cast(CourseSerializer, serializer)
-        course = course_serializer.save()
-        request_user = self.request.user
-        if not isinstance(request_user, User):
-            raise exceptions.NotAuthenticated(
-                "Authentication is required to create a course."
-            )
-        if not request_user.is_authenticated:
-            raise exceptions.NotAuthenticated(
-                "Authentication is required to create a course."
-            )
+        course = serializer.save()
 
         logger.info(
-            "Course %s (%s) created by %s", course.title, course.pk, self.request.user
+            "Course %s (%s) created by %s", course.title, course.pk, request.user
         )
         CourseMembership.objects.create(
             course=course,
-            user=request_user,
+            user=request.user,
             role="teacher",
             status="enrolled",
         )
         logger.debug(
             "Teacher membership created for user %s in course %s",
-            self.request.user,
+            request.user,
             course.pk,
         )
+
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+
+# --- Course Module Operations ---
+
+
+class CourseModuleListCreateView(CoursesAppBaseAPIView):
+    """List and create modules for a course."""
+
+    permission_classes = [IsCourseMember]
+
+    def get_queryset(self, course_id):
+        return (
+            CourseModule.objects.filter(course_id=course_id)
+            .select_related("course", "content_type")
+            .order_by("order")
+        )
+
+    @extend_schema(
+        summary="List course modules",
+        description=(
+            "List all modules for a course, ordered by the order field. "
+            "Only enrolled course members can view modules."
+        ),
+        tags=["Course Modules"],
+        responses={
+            200: OpenApiResponse(
+                description="List of course modules.",
+                response=CourseModuleSerializer(many=True),
+            ),
+            401: OpenApiResponse(description="Authentication required."),
+            403: OpenApiResponse(description="Not a course member."),
+            404: OpenApiResponse(description="Course not found."),
+        },
+    )
+    def get(self, request, pk, *args, **kwargs):
+        get_object_or_404(Course, pk=pk)
+        modules = self.get_queryset(pk)
+        serializer = CourseModuleSerializer(
+            modules, many=True, context=self.get_serializer_context()
+        )
+        return Response(serializer.data)
+
+    @extend_schema(
+        summary="Create a course module",
+        description=(
+            "Create a new module in the course. Only course teachers can create modules. "
+            "The course is automatically set from the URL."
+        ),
+        tags=["Course Modules"],
+        request=inline_serializer(
+            name="CourseModuleCreateRequest",
+            fields={
+                "title": serializers.CharField(
+                    required=False, help_text="Module title"
+                ),
+                "order": serializers.IntegerField(
+                    required=False, help_text="Display order (default 0)"
+                ),
+                "content_type": serializers.CharField(
+                    help_text="Content type as 'app_label.model'"
+                ),
+                "object_id": serializers.IntegerField(
+                    help_text="ID of the content object"
+                ),
+            },
+        ),
+        responses={
+            201: OpenApiResponse(
+                description="Module created successfully.",
+                response=CourseModuleSerializer,
+            ),
+            400: OpenApiResponse(description="Validation error."),
+            401: OpenApiResponse(description="Authentication required."),
+            403: OpenApiResponse(description="Only teachers can create modules."),
+            404: OpenApiResponse(description="Course not found."),
+        },
+        examples=[
+            OpenApiExample(
+                "Create module",
+                summary="Create a module linked to a chatroom",
+                request_only=True,
+                value={
+                    "title": "Week 1: Introduction",
+                    "order": 1,
+                    "content_type": "chat.chatroom",
+                    "object_id": 1,
+                },
+            ),
+        ],
+    )
+    @transaction.atomic
+    def post(self, request, pk, *args, **kwargs):
+        if not IsCourseTeacher().has_permission(request, self):
+            raise exceptions.PermissionDenied(IsCourseTeacher.message)
+
+        course = get_object_or_404(Course, pk=pk)
+
+        data = request.data.copy()
+        data["course"] = course.pk
+
+        serializer = CourseModuleSerializer(
+            data=data, context=self.get_serializer_context()
+        )
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        serializer.save()
+        logger.info(
+            "Module created in course %s (%s) by %s",
+            course.title,
+            course.pk,
+            request.user,
+        )
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+
+class CourseModuleDetailView(CoursesAppBaseAPIView):
+    """Retrieve, update, or delete a single course module."""
+
+    permission_classes = [IsCourseMember]
+
+    def get_object(self, pk, module_id):
+        return get_object_or_404(
+            CourseModule.objects.select_related("course", "content_type"),
+            pk=module_id,
+            course_id=pk,
+        )
+
+    @extend_schema(
+        summary="Retrieve a course module",
+        description="Get details of a single module. Only enrolled course members can view.",
+        tags=["Course Modules"],
+        responses={
+            200: OpenApiResponse(
+                description="Module details.", response=CourseModuleSerializer
+            ),
+            401: OpenApiResponse(description="Authentication required."),
+            403: OpenApiResponse(description="Not a course member."),
+            404: OpenApiResponse(description="Module or course not found."),
+        },
+    )
+    def get(self, request, pk, module_id, *args, **kwargs):
+        module = self.get_object(pk, module_id)
+        serializer = CourseModuleSerializer(
+            module, context=self.get_serializer_context()
+        )
+        return Response(serializer.data)
+
+    @extend_schema(
+        summary="Update a course module",
+        description=(
+            "Partially update a module's fields (title, order, content_type, object_id). "
+            "Only course teachers can update modules."
+        ),
+        tags=["Course Modules"],
+        request=CourseModuleSerializer,
+        responses={
+            200: OpenApiResponse(
+                description="Module updated successfully.",
+                response=CourseModuleSerializer,
+            ),
+            400: OpenApiResponse(description="Validation error."),
+            401: OpenApiResponse(description="Authentication required."),
+            403: OpenApiResponse(description="Only teachers can update modules."),
+            404: OpenApiResponse(description="Module or course not found."),
+        },
+    )
+    @transaction.atomic
+    def patch(self, request, pk, module_id, *args, **kwargs):
+        if not IsCourseTeacher().has_permission(request, self):
+            raise exceptions.PermissionDenied(IsCourseTeacher.message)
+
+        module = self.get_object(pk, module_id)
+        serializer = CourseModuleSerializer(
+            module,
+            data=request.data,
+            partial=True,
+            context=self.get_serializer_context(),
+        )
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        serializer.save()
+        logger.info(
+            "Module %s updated in course %s by %s",
+            module_id,
+            pk,
+            request.user,
+        )
+        return Response(serializer.data)
+
+    @extend_schema(
+        summary="Delete a course module",
+        description="Remove a module from the course. Only course teachers can delete modules.",
+        tags=["Course Modules"],
+        responses={
+            204: OpenApiResponse(description="Module deleted successfully."),
+            401: OpenApiResponse(description="Authentication required."),
+            403: OpenApiResponse(description="Only teachers can delete modules."),
+            404: OpenApiResponse(description="Module or course not found."),
+        },
+    )
+    @transaction.atomic
+    def delete(self, request, pk, module_id, *args, **kwargs):
+        if not IsCourseTeacher().has_permission(request, self):
+            raise exceptions.PermissionDenied(IsCourseTeacher.message)
+
+        module = self.get_object(pk, module_id)
+        logger.info(
+            "Module %s deleted from course %s by %s",
+            module_id,
+            pk,
+            request.user,
+        )
+        module.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
# Courses API: Module CRUD endpoints + standards compliance

Closes #230

## Problem

The courses app had a single `CourseCreateView` that inherited from `generics.CreateAPIView`, violating the project's backend coding standards. There was no base view class, and course modules (`CourseModule`) had a model and serializer but no API endpoints — teachers had no way to manage course content structure through the API.

## Changes

### Refactor: `CoursesAppBaseAPIView`
**`backend/EduLite/courses/views.py`**

Added a base view class following the established `UsersAppBaseAPIView` pattern:
- Inherits from `APIView` (not generic views)
- Default `IsAuthenticated` permission
- Provides `get_serializer_context()` with the request object

### Refactor: `CourseCreateView`
**`backend/EduLite/courses/views.py`**

Converted from `generics.CreateAPIView` to `CoursesAppBaseAPIView`:
- Explicit `post()` method with manual serializer validation and response building
- `@transaction.atomic` directly on the method
- Same behaviour as before — creates course and auto-enrolls creator as teacher
- Existing `@extend_schema` documentation preserved and extended with 401/403 responses

### New: `CourseModuleListCreateView`
**`backend/EduLite/courses/views.py`**

Endpoint: `GET/POST /api/courses/<int:pk>/modules/`

- **GET**: Lists all modules for a course, ordered by `order` field. Uses `select_related("course", "content_type")`. Accessible to enrolled course members (`IsCourseMember`).
- **POST**: Creates a new module. Teacher-only (manual `IsCourseTeacher` check). Auto-sets `course` from URL. Wrapped in `@transaction.atomic`.

### New: `CourseModuleDetailView`
**`backend/EduLite/courses/views.py`**

Endpoint: `GET/PATCH/DELETE /api/courses/<int:pk>/modules/<int:module_id>/`

- **GET**: Retrieve a single module. Course members only.
- **PATCH**: Partial update (title, order, content_type, object_id). Teacher-only. `@transaction.atomic`.
- **DELETE**: Remove module. Teacher-only. `@transaction.atomic`.

All methods use `select_related` and have full `@extend_schema` documentation.

### Fix: `CourseModuleSerializer.validate()` partial update bug
**`backend/EduLite/courses/serializers.py`**

The `validate()` method accessed `attrs["content_type"]` unconditionally, causing a `KeyError` on partial updates (PATCH) that don't include `content_type`. Fixed to use `attrs.get("content_type", getattr(self.instance, ...))` pattern — same approach used for `CourseSerializer.validate()`.

### New: URL patterns
**`backend/EduLite/courses/urls.py`**

| Pattern | View | Name |
|---------|------|------|
| `courses/<int:pk>/modules/` | `CourseModuleListCreateView` | `course-module-list-create` |
| `courses/<int:pk>/modules/<int:module_id>/` | `CourseModuleDetailView` | `course-module-detail` |

### New: Tests
**`backend/EduLite/courses/tests/test_api_modules.py`**

13 test cases covering all CRUD operations and permission boundaries:

| Test | Method | Expected |
|------|--------|----------|
| List modules as member | GET | 200, ordered by `order` |
| List modules as non-member | GET | 403 |
| List modules unauthenticated | GET | 401 |
| Create module as teacher | POST | 201, module created |
| Create module as student | POST | 403 |
| Create module invalid content_type | POST | 400 |
| Retrieve module as member | GET | 200 |
| Retrieve module as non-member | GET | 403 |
| Retrieve module not found | GET | 404 |
| Update module as teacher | PATCH | 200, fields updated |
| Update module as student | PATCH | 403 |
| Delete module as teacher | DELETE | 204, module removed |
| Delete module as student | DELETE | 403 |

## What's NOT changed

- `CourseSerializer`, `CourseMembershipSerializer`, `CourseChatRoomSerializer` — untouched
- Permission classes — reused as-is (`IsCourseMember`, `IsCourseTeacher`, `CanCreateCourse`)
- `CoursePagination` — exists but not used here (module lists per course are small)
- All existing model and serializer tests — untouched

## Testing

All 74 courses tests pass, including the 13 new ones:

```
Ran 74 tests in 0.277s
OK
```
