### PR TITLE
schema for models

### DIFF
--- a/backend/EduLite/EduLite/settings.py
+++ b/backend/EduLite/EduLite/settings.py
@@ -11,12 +11,11 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
 import sys
-
 from datetime import timedelta
 from pathlib import Path
 
-from decouple import config
 import dj_database_url
+from decouple import config
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -70,6 +69,7 @@ INSTALLED_APPS = [
     "corsheaders",
     "drf_spectacular",
     "drf_spectacular_sidecar",
+    "schema_graph",
     "django_spellbook",
     "django_mercury",
 ]

--- a/backend/EduLite/EduLite/urls.py
+++ b/backend/EduLite/EduLite/urls.py
@@ -3,16 +3,18 @@
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
-from django.urls import path, include
+from django.urls import include, path
 from drf_spectacular.views import (
     SpectacularAPIView,
-    SpectacularSwaggerView,
     SpectacularRedocView,
+    SpectacularSwaggerView,
 )
+from schema_graph.views import Schema
 from users.jwt_views import (
     CustomTokenObtainPairView,
     CustomTokenRefreshView,
 )
+
 from .health import health_check
 
 urlpatterns = [
@@ -30,6 +32,7 @@ urlpatterns = [
     path("api/", include("users.urls")),
     path("api/chat/", include("chat.urls")),
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
+    path("schema/", Schema.as_view()),
     path("swagger/", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger"),
     path("redoc/", SpectacularRedocView.as_view(url_name="schema"), name="redoc"),
     path("api/", include("courses.urls")),

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,6 +17,7 @@ daphne==4.2.1
 Django==5.2.1
 django-cors-headers==4.7.0
 django-mercury-performance==0.1.3b6
+django-schema-graph==3.1.0
 django-spellbook==0.2.5b14
 djangorestframework==3.16.0
 djangorestframework_simplejwt==5.5.0


### PR DESCRIPTION
# Add django-schema-graph for interactive model visualization

Closes #234

## Problem

EduLite has 6 backend apps with models that reference each other through ForeignKeys, GenericForeignKeys, and intermediary tables. There's no quick way for contributors to visualize how the models connect — you have to read through multiple `models.py` files to understand the data layer.

## Changes

### `backend/requirements.txt`
- Added `django-schema-graph==3.1.0`

### `backend/EduLite/EduLite/settings.py`
- Added `"schema_graph"` to `INSTALLED_APPS`

### `backend/EduLite/EduLite/urls.py`
- Added `path("schema/", Schema.as_view())` — serves the interactive model diagram

## How to use

1. Run the dev server (`python manage.py runserver`)
2. Browse to `/schema/`
3. Toggle apps and models on/off to focus on specific relationships

Only visible when `DEBUG=True` — no security concern for production. No migrations, no database changes.

## Testing

No new tests needed — this is a dev tooling addition with no effect on application logic. Existing tests are unaffected.
