### PR TITLE
course join and leave API

### DIFF
--- a/backend/EduLite/courses/tests/test_api_enrollment.py
+++ b/backend/EduLite/courses/tests/test_api_enrollment.py
@@ -1,0 +1,198 @@
+"""Tests for the course enrollment (join/leave) API endpoints."""
+
+from datetime import datetime
+from typing import Optional
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from courses.models import Course, CourseMembership
+
+
+class CourseEnrollAPITests(APITestCase):
+    """Validate POST (join) and DELETE (leave) on /api/courses/<pk>/enroll/."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user_model = get_user_model()
+
+        cls.teacher = cls._make_user("teacher_user", "teacher")
+        cls.student = cls._make_user("student_user", "student")
+        cls.outsider = cls._make_user("outsider_user", "student")
+
+        # Public course
+        cls.public_course = Course.objects.create(
+            title="Public Course",
+            visibility="public",
+            start_date=datetime(2025, 1, 1),
+            end_date=datetime(2025, 12, 31),
+        )
+        CourseMembership.objects.create(
+            course=cls.public_course,
+            user=cls.teacher,
+            role="teacher",
+            status="enrolled",
+        )
+
+        # Restricted course with join requests
+        cls.restricted_open = Course.objects.create(
+            title="Restricted Open",
+            visibility="restricted",
+            allow_join_requests=True,
+            start_date=datetime(2025, 1, 1),
+            end_date=datetime(2025, 12, 31),
+        )
+        CourseMembership.objects.create(
+            course=cls.restricted_open,
+            user=cls.teacher,
+            role="teacher",
+            status="enrolled",
+        )
+
+        # Restricted course without join requests
+        cls.restricted_closed = Course.objects.create(
+            title="Restricted Closed",
+            visibility="restricted",
+            allow_join_requests=False,
+            start_date=datetime(2025, 1, 1),
+            end_date=datetime(2025, 12, 31),
+        )
+
+        # Private course
+        cls.private_course = Course.objects.create(
+            title="Private Course",
+            visibility="private",
+            start_date=datetime(2025, 1, 1),
+            end_date=datetime(2025, 12, 31),
+        )
+
+    @classmethod
+    def _make_user(cls, username: str, occupation: Optional[str] = None):
+        user = cls.user_model.objects.create_user(
+            username=username, password="test-pass-123"
+        )
+        if occupation is not None:
+            profile = user.profile
+            profile.occupation = occupation
+            profile.save()
+        return user
+
+    def _enroll_url(self, course):
+        return reverse("course-enroll", kwargs={"pk": course.pk})
+
+    # --- Join (POST) ---
+
+    def test_join_public_course(self):
+        """Joining a public course creates an enrolled membership."""
+        self.client.force_authenticate(user=self.outsider)
+
+        response = self.client.post(self._enroll_url(self.public_course))
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["status"], "enrolled")
+        self.assertEqual(response.data["role"], "student")
+
+        # Cleanup
+        CourseMembership.objects.filter(
+            course=self.public_course, user=self.outsider
+        ).delete()
+
+    def test_join_restricted_with_join_requests(self):
+        """Joining a restricted course with allow_join_requests creates a pending membership."""
+        self.client.force_authenticate(user=self.outsider)
+
+        response = self.client.post(self._enroll_url(self.restricted_open))
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["status"], "pending")
+        self.assertEqual(response.data["role"], "student")
+
+        # Cleanup
+        CourseMembership.objects.filter(
+            course=self.restricted_open, user=self.outsider
+        ).delete()
+
+    def test_join_restricted_without_join_requests(self):
+        """Joining a restricted course without allow_join_requests is denied."""
+        self.client.force_authenticate(user=self.outsider)
+
+        response = self.client.post(self._enroll_url(self.restricted_closed))
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_join_private_course(self):
+        """Joining a private course is denied."""
+        self.client.force_authenticate(user=self.outsider)
+
+        response = self.client.post(self._enroll_url(self.private_course))
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_join_already_member(self):
+        """Joining a course you're already in returns 409."""
+        self.client.force_authenticate(user=self.teacher)
+
+        response = self.client.post(self._enroll_url(self.public_course))
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+
+    def test_join_unauthenticated(self):
+        """Unauthenticated users cannot join courses."""
+        response = self.client.post(self._enroll_url(self.public_course))
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    # --- Leave (DELETE) ---
+
+    def test_leave_course(self):
+        """A member can leave a course."""
+        # Create a membership to leave
+        membership = CourseMembership.objects.create(
+            course=self.public_course,
+            user=self.student,
+            role="student",
+            status="enrolled",
+        )
+        self.client.force_authenticate(user=self.student)
+
+        response = self.client.delete(self._enroll_url(self.public_course))
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(CourseMembership.objects.filter(pk=membership.pk).exists())
+
+    def test_last_teacher_cannot_leave(self):
+        """The last teacher in a course cannot leave."""
+        # Create a solo-teacher course
+        solo_course = Course.objects.create(
+            title="Solo Teacher Course",
+            visibility="public",
+            start_date=datetime(2025, 1, 1),
+            end_date=datetime(2025, 12, 31),
+        )
+        CourseMembership.objects.create(
+            course=solo_course,
+            user=self.teacher,
+            role="teacher",
+            status="enrolled",
+        )
+        self.client.force_authenticate(user=self.teacher)
+
+        response = self.client.delete(self._enroll_url(solo_course))
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+
+    def test_non_member_leave(self):
+        """Leaving a course you're not in returns 404."""
+        self.client.force_authenticate(user=self.outsider)
+
+        response = self.client.delete(self._enroll_url(self.public_course))
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_leave_unauthenticated(self):
+        """Unauthenticated users cannot leave courses."""
+        response = self.client.delete(self._enroll_url(self.public_course))
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/backend/EduLite/courses/urls.py
+++ b/backend/EduLite/courses/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from .views import (
     CourseCreateView,
+    CourseEnrollView,
     CourseMembershipDetailView,
     CourseMembershipListInviteView,
     CourseModuleDetailView,
@@ -29,5 +30,10 @@ urlpatterns = [
         "courses/<int:pk>/members/<int:membership_id>/",
         CourseMembershipDetailView.as_view(),
         name="course-membership-detail",
+    ),
+    path(
+        "courses/<int:pk>/enroll/",
+        CourseEnrollView.as_view(),
+        name="course-enroll",
     ),
 ]


### PR DESCRIPTION
# Courses API: Basic enrollment (join + leave)

Closes #228

## Problem

Users had no way to join or leave courses through the API. Course membership was only created automatically when a course was created (teacher) or when a teacher invited someone (via #229). There was no self-service enrollment endpoint.

## Changes

### New: `CourseEnrollView`
**`backend/EduLite/courses/views.py`**

Endpoint: `POST/DELETE /api/courses/<int:pk>/enroll/`

Permission: `IsAuthenticated` (any logged-in user can attempt to join).

- **POST** (join): Creates a membership based on course visibility:

  | Visibility | `allow_join_requests` | Result |
  |------------|-----------------------|--------|
  | `public` | — | `status="enrolled"`, **201** |
  | `restricted` | `True` | `status="pending"`, **201** |
  | `restricted` | `False` | **403** |
  | `private` | — | **403** |

  Returns **409 Conflict** if the user is already a member. Wrapped in `@transaction.atomic`.

- **DELETE** (leave): Removes the user's own membership. **Last-teacher protection**: the last enrolled teacher cannot leave (returns 409). Returns **204** on success, **404** if not a member. Wrapped in `@transaction.atomic`.

### New: URL pattern
**`backend/EduLite/courses/urls.py`**

| Pattern | View | Name |
|---------|------|------|
| `courses/<int:pk>/enroll/` | `CourseEnrollView` | `course-enroll` |

### New: Tests
**`backend/EduLite/courses/tests/test_api_enrollment.py`**

10 test cases:

| Test | Method | Expected |
|------|--------|----------|
| Join public course | POST | 201, status=enrolled |
| Join restricted + allow_join_requests | POST | 201, status=pending |
| Join restricted without allow_join_requests | POST | 403 |
| Join private course | POST | 403 |
| Join when already a member | POST | 409 |
| Join unauthenticated | POST | 401 |
| Leave course | DELETE | 204 |
| Last teacher cannot leave | DELETE | 409 |
| Non-member leave | DELETE | 404 |
| Leave unauthenticated | DELETE | 401 |

## What's NOT changed

- `Course` and `CourseMembership` models — untouched
- `CourseMembershipSerializer` — reused as-is for response serialization
- Permission classes — reused (`IsAuthenticated` from base class)
- All existing views, serializers, and tests — untouched

## Testing

All 98 courses tests pass, including the 10 new ones:

```
Ran 98 tests in 0.365s
OK
```
