### PR TITLE
course list

### DIFF
--- a/backend/EduLite/courses/tests/test_api_course_create.py
+++ b/backend/EduLite/courses/tests/test_api_course_create.py
@@ -7,9 +7,9 @@ from django.contrib.auth import get_user_model
 from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
+from django_mercury import monitor
 from rest_framework import status
 from rest_framework.test import APITestCase
-from django_mercury import monitor
 
 from courses.models import Course, CourseMembership
 
@@ -19,7 +19,7 @@ class CourseCreateAPITests(APITestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        self.url = reverse("course-create")
+        self.url = reverse("course-list-create")
         self.user_model = get_user_model()
 
     def _create_user(self, username: str, occupation: Optional[str] = None):

--- a/backend/EduLite/courses/tests/test_api_course_list.py
+++ b/backend/EduLite/courses/tests/test_api_course_list.py
@@ -1,0 +1,207 @@
+"""Tests for the course list API endpoint."""
+
+from datetime import datetime
+from typing import Optional
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from courses.models import Course, CourseMembership
+
+
+class CourseListAPITests(APITestCase):
+    """Validate GET /api/courses/ behaviour."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user_model = get_user_model()
+        cls.url = reverse("course-list-create")
+
+        cls.teacher = cls._make_user("teacher_user", "teacher")
+        cls.student = cls._make_user("student_user", "student")
+        cls.outsider = cls._make_user("outsider_user", "student")
+
+        # Public course — visible to everyone
+        cls.public_course = Course.objects.create(
+            title="Public Physics",
+            visibility="public",
+            subject="physics",
+            language="en",
+            country="US",
+            start_date=datetime(2025, 1, 1),
+            end_date=datetime(2025, 12, 31),
+        )
+        CourseMembership.objects.create(
+            course=cls.public_course,
+            user=cls.teacher,
+            role="teacher",
+            status="enrolled",
+        )
+        CourseMembership.objects.create(
+            course=cls.public_course,
+            user=cls.student,
+            role="student",
+            status="enrolled",
+        )
+
+        # Private course — only visible to members
+        cls.private_course = Course.objects.create(
+            title="Private Math",
+            visibility="private",
+            subject="mathematics",
+            language="fr",
+            country="FR",
+            start_date=datetime(2025, 1, 1),
+            end_date=datetime(2025, 12, 31),
+        )
+        CourseMembership.objects.create(
+            course=cls.private_course,
+            user=cls.teacher,
+            role="teacher",
+            status="enrolled",
+        )
+
+        # Restricted course — only visible to members
+        cls.restricted_course = Course.objects.create(
+            title="Restricted Chemistry",
+            visibility="restricted",
+            subject="chemistry",
+            language="en",
+            country="GB",
+            start_date=datetime(2025, 1, 1),
+            end_date=datetime(2025, 12, 31),
+        )
+        CourseMembership.objects.create(
+            course=cls.restricted_course,
+            user=cls.teacher,
+            role="teacher",
+            status="enrolled",
+        )
+
+    @classmethod
+    def _make_user(cls, username: str, occupation: Optional[str] = None):
+        user = cls.user_model.objects.create_user(
+            username=username, password="test-pass-123"
+        )
+        if occupation is not None:
+            profile = user.profile
+            profile.occupation = occupation
+            profile.save()
+        return user
+
+    # --- Basic list behaviour ---
+
+    def test_list_returns_paginated_shape(self):
+        """Response has the expected pagination keys."""
+        self.client.force_authenticate(user=self.teacher)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for key in ("count", "results", "total_pages", "current_page", "page_size"):
+            self.assertIn(key, response.data)
+
+    def test_public_courses_visible_to_all_authenticated(self):
+        """An outsider (non-member) can see public courses."""
+        self.client.force_authenticate(user=self.outsider)
+
+        response = self.client.get(self.url)
+
+        titles = [c["title"] for c in response.data["results"]]
+        self.assertIn("Public Physics", titles)
+
+    def test_private_courses_hidden_from_non_members(self):
+        """An outsider cannot see private or restricted courses."""
+        self.client.force_authenticate(user=self.outsider)
+
+        response = self.client.get(self.url)
+
+        titles = [c["title"] for c in response.data["results"]]
+        self.assertNotIn("Private Math", titles)
+        self.assertNotIn("Restricted Chemistry", titles)
+
+    def test_private_courses_visible_to_members(self):
+        """A member can see private courses they belong to."""
+        self.client.force_authenticate(user=self.teacher)
+
+        response = self.client.get(self.url)
+
+        titles = [c["title"] for c in response.data["results"]]
+        self.assertIn("Private Math", titles)
+        self.assertIn("Restricted Chemistry", titles)
+
+    def test_unauthenticated_returns_401(self):
+        """Unauthenticated users cannot list courses."""
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    # --- Filters ---
+
+    def test_filter_by_visibility(self):
+        """Filtering by visibility returns only matching courses."""
+        self.client.force_authenticate(user=self.teacher)
+
+        response = self.client.get(self.url, {"visibility": "public"})
+
+        titles = [c["title"] for c in response.data["results"]]
+        self.assertIn("Public Physics", titles)
+        self.assertNotIn("Private Math", titles)
+        self.assertNotIn("Restricted Chemistry", titles)
+
+    def test_filter_by_subject(self):
+        """Filtering by subject returns only matching courses."""
+        self.client.force_authenticate(user=self.teacher)
+
+        response = self.client.get(self.url, {"subject": "mathematics"})
+
+        titles = [c["title"] for c in response.data["results"]]
+        self.assertIn("Private Math", titles)
+        self.assertNotIn("Public Physics", titles)
+
+    def test_filter_by_language(self):
+        """Filtering by language returns only matching courses."""
+        self.client.force_authenticate(user=self.teacher)
+
+        response = self.client.get(self.url, {"language": "fr"})
+
+        titles = [c["title"] for c in response.data["results"]]
+        self.assertIn("Private Math", titles)
+        self.assertNotIn("Public Physics", titles)
+
+    def test_filter_by_country(self):
+        """Filtering by country returns only matching courses."""
+        self.client.force_authenticate(user=self.teacher)
+
+        response = self.client.get(self.url, {"country": "GB"})
+
+        titles = [c["title"] for c in response.data["results"]]
+        self.assertIn("Restricted Chemistry", titles)
+        self.assertNotIn("Public Physics", titles)
+
+    def test_filter_mine(self):
+        """Filtering mine=true returns only the user's courses."""
+        self.client.force_authenticate(user=self.student)
+
+        response = self.client.get(self.url, {"mine": "true"})
+
+        titles = [c["title"] for c in response.data["results"]]
+        # Student is only a member of the public course
+        self.assertIn("Public Physics", titles)
+        self.assertEqual(len(titles), 1)
+
+    # --- Annotation ---
+
+    def test_member_count_is_correct(self):
+        """The member_count field reflects enrolled members."""
+        self.client.force_authenticate(user=self.teacher)
+
+        response = self.client.get(self.url, {"visibility": "public"})
+
+        public = next(
+            c for c in response.data["results"] if c["title"] == "Public Physics"
+        )
+        # teacher + student = 2 enrolled members
+        self.assertEqual(public["member_count"], 2)

--- a/backend/EduLite/courses/tests/test_permissions.py
+++ b/backend/EduLite/courses/tests/test_permissions.py
@@ -6,10 +6,10 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from rest_framework import status
-from rest_framework.test import APITestCase, APIRequestFactory
+from rest_framework.test import APIRequestFactory, APITestCase
 
 from courses.models import Course, CourseMembership
-from courses.permissions import CanCreateCourse, IsCourseTeacher, IsCourseMember
+from courses.permissions import CanCreateCourse, IsCourseMember, IsCourseTeacher
 
 User = get_user_model()
 
@@ -18,7 +18,7 @@ class CanCreateCoursePermissionTests(APITestCase):
     """Test the CanCreateCourse permission with setting toggle."""
 
     def setUp(self):
-        self.url = reverse("course-create")
+        self.url = reverse("course-list-create")
 
     def _create_user(self, username: str, occupation: Optional[str] = None):
         user = User.objects.create_user(username=username, password="test-pass-123")

--- a/backend/EduLite/courses/urls.py
+++ b/backend/EduLite/courses/urls.py
@@ -1,9 +1,9 @@
 from django.urls import path
 
 from .views import (
-    CourseCreateView,
     CourseDetailView,
     CourseEnrollView,
+    CourseListCreateView,
     CourseMembershipDetailView,
     CourseMembershipListInviteView,
     CourseModuleDetailView,
@@ -11,7 +11,7 @@ from .views import (
 )
 
 urlpatterns = [
-    path("courses/", CourseCreateView.as_view(), name="course-create"),
+    path("courses/", CourseListCreateView.as_view(), name="course-list-create"),
     path("courses/<int:pk>/", CourseDetailView.as_view(), name="course-detail"),
     path(
         "courses/<int:pk>/modules/",


### PR DESCRIPTION
## Description

Add course list, detail, and enrollment endpoints to the courses API, completing the core course CRUD lifecycle and enabling course discovery and membership management.

**Course List** (`GET /api/courses/`):
- Paginated list of courses visible to the requesting user (public courses for all, private/restricted only for members).
- Query param filters: `visibility`, `subject`, `language`, `country`, `mine` (bool).
- Annotated `member_count` for each course.
- Renamed `CourseCreateView` to `CourseListCreateView` to combine list + create on the same endpoint.

**Course Detail** (`/api/courses/<int:pk>/`):
- **GET**: Full course details including nested members, modules, and the requesting user's role. Uses `CourseDetailSerializer`. Requires enrolled membership.
- **PATCH**: Partial update of course fields. Teacher-only. Validates title and date constraints.
- **DELETE**: Delete course and all associated data via FK cascades. Teacher-only.
- **PUT**: Returns 405 (only partial updates via PATCH).

**Enrollment** (`/api/courses/<int:pk>/enroll/`):
- **POST** (join): Public courses enroll immediately. Restricted courses with `allow_join_requests` create pending membership. Private/restricted-closed courses return 403. Already-a-member returns 409.
- **DELETE** (leave): Removes the requesting user's membership. Last teacher cannot leave (409). Non-member returns 404.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Documentation update

## Testing
- [x] Manually reviewed the change
- [x] 11 new tests for course list (pagination, visibility rules, all filters, member_count, auth)
- [x] 15 new tests for course detail (GET/PATCH/DELETE permissions, validation, PUT 405)
- [x] 11 new tests for enrollment (join public/restricted/private, already member, leave, last teacher, non-member, unauthenticated)
- [x] Full courses test suite passes (124 tests, 0 failures)

## Related Issues
Closes #226
Closes #227
Closes #228
