### PR TITLE
Rename 'Chapters' to 'Courses' in Navbar, Sidebar, and i18n

### DIFF
--- a/Frontend/EduLiteFrontend/src/components/Navbar.tsx
+++ b/Frontend/EduLiteFrontend/src/components/Navbar.tsx
@@ -20,7 +20,9 @@ export default function Navbar({ isLoggedIn }: NavbarProps) {
   const navigate = useNavigate();
 
   const isActiveRoute = (path: string): boolean =>
-    path === "/" ? location.pathname === "/" : location.pathname.startsWith(path);
+    path === "/"
+      ? location.pathname === "/"
+      : location.pathname.startsWith(path);
 
   const handleProfileClick = () => {
     navigate("/profile");
@@ -55,7 +57,7 @@ export default function Navbar({ isLoggedIn }: NavbarProps) {
                 { to: "/", label: t("nav.home") },
                 { to: "/about", label: t("nav.about") },
                 { to: "/conversations", label: t("nav.conversations") },
-                { to: "/chapters", label: t("nav.chapters") },
+                { to: "/courses", label: t("nav.courses") },
                 { to: "/slideshows", label: t("nav.slideshows") },
               ].map((link) => (
                 <Link

--- a/Frontend/EduLiteFrontend/src/components/Sidebar.jsx
+++ b/Frontend/EduLiteFrontend/src/components/Sidebar.jsx
@@ -13,7 +13,10 @@ import {
   HiCog,
 } from "react-icons/hi";
 import { FaSignOutAlt } from "react-icons/fa";
-import { HiArrowRightOnRectangle, HiPresentationChartBar } from "react-icons/hi2";
+import {
+  HiArrowRightOnRectangle,
+  HiPresentationChartBar,
+} from "react-icons/hi2";
 
 export default function SidebarMenu({ open, onClose }) {
   const { t, i18n } = useTranslation();
@@ -35,8 +38,12 @@ export default function SidebarMenu({ open, onClose }) {
     { to: "/", label: t("nav.home"), icon: HiHome },
     { to: "/about", label: t("nav.about"), icon: HiInformationCircle },
     { to: "/conversations", label: t("nav.conversations"), icon: HiChatAlt2 },
-    { to: "/chapters", label: t("nav.chapters"), icon: HiBookOpen },
-    { to: "/slideshows", label: t("nav.slideshows"), icon: HiPresentationChartBar },
+    { to: "/courses", label: t("nav.courses"), icon: HiBookOpen },
+    {
+      to: "/slideshows",
+      label: t("nav.slideshows"),
+      icon: HiPresentationChartBar,
+    },
     { to: "/settings", label: t("nav.settings"), icon: HiCog },
   ];
 
@@ -151,7 +158,9 @@ export default function SidebarMenu({ open, onClose }) {
         confirmText="Logout"
         cancelText="Cancel"
         confirmButtonClass="bg-red-600 hover:bg-red-700 text-white"
-        icon={<HiArrowRightOnRectangle className="w-12 h-12 text-red-600 dark:text-red-400" />}
+        icon={
+          <HiArrowRightOnRectangle className="w-12 h-12 text-red-600 dark:text-red-400" />
+        }
       />
     </>
   );

--- a/Frontend/EduLiteFrontend/src/i18n/locales/ar.json
+++ b/Frontend/EduLiteFrontend/src/i18n/locales/ar.json
@@ -11,7 +11,7 @@
     "home": "الرئيسية",
     "about": "حول المنصة",
     "conversations": "المحادثات",
-    "chapters": "الفصول",
+    "courses": "الدورات",
     "slideshows": "العروض التقديمية",
     "profile": "الملف الشخصي",
     "settings": "الإعدادات",

--- a/Frontend/EduLiteFrontend/src/i18n/locales/en.json
+++ b/Frontend/EduLiteFrontend/src/i18n/locales/en.json
@@ -11,7 +11,7 @@
     "home": "Home",
     "about": "About",
     "conversations": "Conversations",
-    "chapters": "Chapters",
+    "courses": "Courses",
     "slideshows": "Slideshows",
     "profile": "Profile",
     "settings": "Settings",


### PR DESCRIPTION
# Rename 'Chapters' to 'Courses' in Navbar, Sidebar, and i18n

## Description

Aligns frontend navigation with backend terminology. The backend courses API is built — the frontend still said "Chapters." This updates the nav label, route path, and both language files.

Closes #246

## Mandatory Checklist

- [x] I have read and followed the [[CODING_STANDARDS.md](https://github.com/ibrahim-sisar/EduLite/blob/main/backend/CODING_STANDARDS.md)](https://github.com/ibrahim-sisar/EduLite/blob/main/backend/CODING_STANDARDS.md) (backend) or frontend conventions
- [x] I have linked the related issue above
- [x] My branch is up to date with `main`
- [x] I have tested my changes locally
- [x] I have added or updated tests where applicable
- [x] I have not introduced any new linting errors
- [x] My commit messages are clear and descriptive
- [x] I have updated documentation if my changes affect public APIs, setup steps, or user-facing behavior

## What Changed

4 files, ~4 lines:

- `Navbar.tsx` — nav link path `/chapters` → `/courses`, translation key `nav.chapters` → `nav.courses`
- `Sidebar.jsx` — same change as Navbar
- `en.json` — renamed key `"chapters": "Chapters"` → `"courses": "Courses"`
- `ar.json` — renamed key `"chapters": "الفصول"` → `"courses": "الدورات"`

## How to Test

1. `npm run dev`
2. Desktop: navbar should show "Courses" linking to `/courses`
3. Mobile: open sidebar (hamburger) — should show "Courses" linking to `/courses`
4. Switch language to Arabic — verify "الدورات" appears
5. Toggle dark mode — styling unchanged
6. Check browser console — no errors

## Screenshots (if applicable)

N/A — text-only change, no visual layout differences.