### PR TITLE
slideshows logic and search

### DIFF
--- a/backend/EduLite/slideshows/logic/slideshow_search_logic.py
+++ b/backend/EduLite/slideshows/logic/slideshow_search_logic.py
@@ -1,0 +1,116 @@
+"""Business logic for slideshow search functionality."""
+
+from typing import Optional, Tuple
+
+from django.contrib.auth import get_user_model
+from django.db.models import Q, QuerySet
+from rest_framework import status
+from rest_framework.response import Response
+
+User = get_user_model()
+
+
+def validate_search_query(
+    search_query: str, min_length: int = 2
+) -> Tuple[bool, Optional[Response]]:
+    """
+    Validates the search query parameters.
+
+    Args:
+        search_query: The search query string to validate
+        min_length: Minimum required length for the search query
+
+    Returns:
+        Tuple of (is_valid, error_response_or_none)
+        - If valid: (True, None)
+        - If invalid: (False, Response with error details)
+    """
+    if not search_query or not search_query.strip():
+        return False, Response(
+            {"detail": "Search query is required."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    search_query = search_query.strip()
+
+    if len(search_query) < min_length:
+        return False, Response(
+            {"detail": f"Search query must be at least {min_length} characters long."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    return True, None
+
+
+def build_slideshow_search_queryset(
+    search_query: str,
+    user,
+) -> QuerySet:
+    """
+    Creates a search queryset that respects slideshow visibility rules.
+
+    Users see:
+    - Their own slideshows (any visibility, any published state)
+    - Public published slideshows from other users
+
+    Args:
+        search_query: The validated search query string
+        user: The authenticated user performing the search
+
+    Returns:
+        QuerySet of Slideshow objects matching the search criteria
+    """
+    from slideshows.models import Slideshow
+
+    search_query = search_query.strip()
+
+    # Visibility: own slideshows + public published from others
+    visibility_filter = Q(created_by=user) | Q(visibility="public", is_published=True)
+
+    # Text search across title and description
+    text_filter = Q(title__icontains=search_query) | Q(
+        description__icontains=search_query
+    )
+
+    queryset = (
+        Slideshow.objects.filter(visibility_filter & text_filter)
+        .select_related("created_by")
+        .order_by("-updated_at")
+    )
+
+    return queryset
+
+
+def apply_slideshow_filters(queryset: QuerySet, params: dict, user) -> QuerySet:
+    """
+    Applies optional filters from query parameters to the search queryset.
+
+    Args:
+        queryset: The base search queryset to filter
+        params: Query parameters dict (from request.query_params)
+        user: The authenticated user (for 'mine' filter)
+
+    Returns:
+        Filtered QuerySet
+    """
+    visibility = params.get("visibility")
+    if visibility:
+        queryset = queryset.filter(visibility=visibility)
+
+    subject = params.get("subject")
+    if subject:
+        queryset = queryset.filter(subject=subject)
+
+    language = params.get("language")
+    if language:
+        queryset = queryset.filter(language=language)
+
+    country = params.get("country")
+    if country:
+        queryset = queryset.filter(country=country)
+
+    mine_only = params.get("mine")
+    if mine_only and mine_only.lower() == "true":
+        queryset = queryset.filter(created_by=user)
+
+    return queryset

--- a/backend/EduLite/slideshows/tests/views/test_SlideshowSearchView.py
+++ b/backend/EduLite/slideshows/tests/views/test_SlideshowSearchView.py
@@ -1,0 +1,331 @@
+"""Tests for SlideshowSearchView."""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+from django_mercury import monitor
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from slideshows.models import Slideshow
+
+User = get_user_model()
+
+
+class SlideshowSearchViewTestCase(TestCase):
+    """Test cases for slideshow search endpoint."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Create test data once for all tests."""
+        cls.user = User.objects.create_user(
+            username="searcher", email="searcher@test.com", password="password123"
+        )
+        cls.other_user = User.objects.create_user(
+            username="other", email="other@test.com", password="password123"
+        )
+
+        # User's own slideshows (various visibility/published states)
+        cls.own_public_published = Slideshow.objects.create(
+            title="My Python Basics",
+            description="Learn Python fundamentals",
+            created_by=cls.user,
+            visibility="public",
+            is_published=True,
+            subject="computer_science",
+        )
+        cls.own_private = Slideshow.objects.create(
+            title="My Private Notes",
+            description="Personal study notes on Python",
+            created_by=cls.user,
+            visibility="private",
+            is_published=True,
+        )
+        cls.own_unpublished = Slideshow.objects.create(
+            title="My Draft Python Course",
+            description="Work in progress",
+            created_by=cls.user,
+            visibility="public",
+            is_published=False,
+        )
+        cls.own_unlisted = Slideshow.objects.create(
+            title="My Unlisted Python Guide",
+            description="Unlisted slideshow",
+            created_by=cls.user,
+            visibility="unlisted",
+            is_published=True,
+        )
+
+        # Other user's slideshows
+        cls.other_public_published = Slideshow.objects.create(
+            title="Advanced Python Patterns",
+            description="Design patterns in Python",
+            created_by=cls.other_user,
+            visibility="public",
+            is_published=True,
+            subject="computer_science",
+        )
+        cls.other_private = Slideshow.objects.create(
+            title="Secret Python Tips",
+            description="Private collection of Python tricks",
+            created_by=cls.other_user,
+            visibility="private",
+            is_published=True,
+        )
+        cls.other_unlisted = Slideshow.objects.create(
+            title="Unlisted Python Workshop",
+            description="Hidden Python workshop slides",
+            created_by=cls.other_user,
+            visibility="unlisted",
+            is_published=True,
+        )
+        cls.other_unpublished = Slideshow.objects.create(
+            title="Unpublished Python Draft",
+            description="Not ready yet",
+            created_by=cls.other_user,
+            visibility="public",
+            is_published=False,
+        )
+
+        # Slideshow with no Python in title/description (for negative match)
+        cls.unrelated = Slideshow.objects.create(
+            title="History of Mathematics",
+            description="From ancient times to modern day",
+            created_by=cls.other_user,
+            visibility="public",
+            is_published=True,
+            subject="mathematics",
+        )
+
+        cls.url = reverse("slideshows:slideshow-search")
+
+    def setUp(self):
+        """Set up test client for each test."""
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    # --- Authentication ---
+
+    def test_unauthenticated_returns_401(self):
+        """Unauthenticated requests should return 401."""
+        self.client.logout()
+        response = self.client.get(self.url, {"q": "Python"})
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    # --- Query Validation ---
+
+    def test_no_query_returns_400(self):
+        """Missing query parameter should return 400."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("detail", response.data)
+
+    def test_empty_query_returns_400(self):
+        """Empty query string should return 400."""
+        response = self.client.get(self.url, {"q": ""})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_whitespace_query_returns_400(self):
+        """Whitespace-only query should return 400."""
+        response = self.client.get(self.url, {"q": "   "})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_single_char_query_returns_400(self):
+        """Single character query should return 400."""
+        response = self.client.get(self.url, {"q": "P"})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("at least 2 characters", response.data["detail"])
+
+    def test_two_char_query_succeeds(self):
+        """Two character query should succeed."""
+        response = self.client.get(self.url, {"q": "Py"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    # --- Title Search ---
+
+    def test_search_matches_title(self):
+        """Should find slideshows matching title."""
+        with monitor(response_time_ms=100, query_count=5):
+            response = self.client.get(self.url, {"q": "Python Basics"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        titles = [r["title"] for r in response.data["results"]]
+        self.assertIn("My Python Basics", titles)
+
+    def test_search_partial_title_match(self):
+        """Should find slideshows with partial title match."""
+        response = self.client.get(self.url, {"q": "Basics"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        titles = [r["title"] for r in response.data["results"]]
+        self.assertIn("My Python Basics", titles)
+
+    def test_search_case_insensitive(self):
+        """Search should be case-insensitive."""
+        response = self.client.get(self.url, {"q": "python basics"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        titles = [r["title"] for r in response.data["results"]]
+        self.assertIn("My Python Basics", titles)
+
+    # --- Description Search ---
+
+    def test_search_matches_description(self):
+        """Should find slideshows matching description."""
+        response = self.client.get(self.url, {"q": "fundamentals"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        titles = [r["title"] for r in response.data["results"]]
+        self.assertIn("My Python Basics", titles)
+
+    def test_search_description_case_insensitive(self):
+        """Description search should be case-insensitive."""
+        response = self.client.get(self.url, {"q": "DESIGN PATTERNS"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        titles = [r["title"] for r in response.data["results"]]
+        self.assertIn("Advanced Python Patterns", titles)
+
+    # --- No Results ---
+
+    def test_no_results_returns_empty_list(self):
+        """Query with no matches should return empty results, not 404."""
+        response = self.client.get(self.url, {"q": "xyznonexistent"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)
+        self.assertEqual(response.data["results"], [])
+
+    # --- Visibility Rules ---
+
+    def test_user_sees_own_private_slideshows(self):
+        """User should see their own private slideshows in search results."""
+        response = self.client.get(self.url, {"q": "Private Notes"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        titles = [r["title"] for r in response.data["results"]]
+        self.assertIn("My Private Notes", titles)
+
+    def test_user_sees_own_unpublished_slideshows(self):
+        """User should see their own unpublished slideshows in search results."""
+        response = self.client.get(self.url, {"q": "Draft Python"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        titles = [r["title"] for r in response.data["results"]]
+        self.assertIn("My Draft Python Course", titles)
+
+    def test_user_sees_own_unlisted_slideshows(self):
+        """User should see their own unlisted slideshows in search results."""
+        response = self.client.get(self.url, {"q": "Unlisted Python Guide"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        titles = [r["title"] for r in response.data["results"]]
+        self.assertIn("My Unlisted Python Guide", titles)
+
+    def test_user_sees_others_public_published(self):
+        """User should see others' public published slideshows."""
+        response = self.client.get(self.url, {"q": "Advanced Python"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        titles = [r["title"] for r in response.data["results"]]
+        self.assertIn("Advanced Python Patterns", titles)
+
+    def test_user_does_not_see_others_private(self):
+        """User should NOT see others' private slideshows."""
+        response = self.client.get(self.url, {"q": "Secret Python"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        titles = [r["title"] for r in response.data["results"]]
+        self.assertNotIn("Secret Python Tips", titles)
+
+    def test_user_does_not_see_others_unlisted(self):
+        """User should NOT see others' unlisted slideshows."""
+        response = self.client.get(self.url, {"q": "Unlisted Python Workshop"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        titles = [r["title"] for r in response.data["results"]]
+        self.assertNotIn("Unlisted Python Workshop", titles)
+
+    def test_user_does_not_see_others_unpublished(self):
+        """User should NOT see others' unpublished slideshows."""
+        response = self.client.get(self.url, {"q": "Unpublished Python"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        titles = [r["title"] for r in response.data["results"]]
+        self.assertNotIn("Unpublished Python Draft", titles)
+
+    # --- Combined Filters ---
+
+    def test_search_with_subject_filter(self):
+        """Search combined with subject filter should narrow results."""
+        # Search "Python" with subject=computer_science
+        response = self.client.get(
+            self.url, {"q": "Python", "subject": "computer_science"}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for result in response.data["results"]:
+            self.assertEqual(result["subject"], "computer_science")
+
+    def test_search_with_mine_filter(self):
+        """Search combined with mine=true should only return user's own slideshows."""
+        response = self.client.get(self.url, {"q": "Python", "mine": "true"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for result in response.data["results"]:
+            self.assertEqual(result["created_by"], self.user.pk)
+
+    def test_search_with_visibility_filter(self):
+        """Search combined with visibility filter should narrow results."""
+        response = self.client.get(self.url, {"q": "Python", "visibility": "private"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for result in response.data["results"]:
+            self.assertEqual(result["visibility"], "private")
+
+    # --- Pagination ---
+
+    def test_results_are_paginated(self):
+        """Search results should include pagination fields."""
+        response = self.client.get(self.url, {"q": "Python"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("count", response.data)
+        self.assertIn("next", response.data)
+        self.assertIn("previous", response.data)
+        self.assertIn("results", response.data)
+        self.assertIn("total_pages", response.data)
+        self.assertIn("current_page", response.data)
+
+    def test_custom_page_size(self):
+        """Custom page_size parameter should be respected."""
+        response = self.client.get(self.url, {"q": "Python", "page_size": 2})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertLessEqual(len(response.data["results"]), 2)
+
+    def test_pagination_with_many_results(self):
+        """Pagination should work correctly with many results."""
+        # Create 25 slideshows to exceed default page size of 20
+        for i in range(25):
+            Slideshow.objects.create(
+                title=f"Bulk Slideshow {i}",
+                description="Bulk test slideshow",
+                created_by=self.user,
+                visibility="public",
+                is_published=True,
+            )
+
+        response = self.client.get(self.url, {"q": "Bulk Slideshow"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 25)
+        self.assertEqual(len(response.data["results"]), 20)  # default page_size
+        self.assertIsNotNone(response.data["next"])
+        self.assertIsNone(response.data["previous"])
+
+    # --- Response Format ---
+
+    def test_response_uses_list_serializer_fields(self):
+        """Response results should contain SlideshowListSerializer fields."""
+        response = self.client.get(self.url, {"q": "Python Basics"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertGreater(len(response.data["results"]), 0)
+
+        result = response.data["results"][0]
+        expected_fields = [
+            "id",
+            "title",
+            "description",
+            "created_by",
+            "created_by_username",
+            "visibility",
+            "is_published",
+            "slide_count",
+            "created_at",
+            "updated_at",
+        ]
+        for field in expected_fields:
+            self.assertIn(field, result)

--- a/backend/EduLite/slideshows/urls.py
+++ b/backend/EduLite/slideshows/urls.py
@@ -1,11 +1,13 @@
 """URL patterns for the slideshows app."""
 
 from django.urls import path
+
 from .views import (
-    SlideshowListCreateView,
-    SlideshowRetrieveUpdateDestroyView,
     SlideCreateView,
     SlideRetrieveUpdateDestroyView,
+    SlideshowListCreateView,
+    SlideshowRetrieveUpdateDestroyView,
+    SlideshowSearchView,
     preview_markdown,
 )
 
@@ -14,6 +16,8 @@ app_name = "slideshows"
 urlpatterns = [
     # Slideshow list and create
     path("", SlideshowListCreateView.as_view(), name="slideshow-list-create"),
+    # Slideshow search
+    path("search/", SlideshowSearchView.as_view(), name="slideshow-search"),
     # Slideshow detail, update, delete
     path(
         "<int:pk>/",


### PR DESCRIPTION
# Add Search Endpoint for Slideshows

## Description

Adds a new `GET /api/slideshows/search/?q=<query>` endpoint for text search across slideshow titles and descriptions. This is needed for the Course Detail Page's "Add Module" flow, where teachers need to find a slideshow to attach to their course.

Closes #262

## Mandatory Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/ibrahim-sisar/EduLite/blob/main/CONTRIBUTING.md)
- [x] I have linked the related issue above
- [x] My branch is up to date with `main`
- [x] I have tested my changes locally
- [x] I have added or updated tests where applicable
- [x] I have not introduced any new linting errors
- [x] My commit messages are clear and descriptive
- [x] I have updated documentation if my changes affect public APIs, setup steps, or user-facing behavior

## What Changed

**New files:**
- `slideshows/logic/__init__.py` — new logic package
- `slideshows/logic/slideshow_search_logic.py` — search business logic (validate query, build visibility-aware queryset, apply filters), following the `users/logic/user_search_logic.py` pattern
- `slideshows/tests/views/test_SlideshowSearchView.py` — 26 tests covering validation, search, visibility, filters, pagination, auth, and response format

**Modified files:**
- `slideshows/views.py` — added `SlideshowsAppBaseAPIView` (per coding standards) and `SlideshowSearchView` with full `@extend_schema` OpenAPI documentation
- `slideshows/urls.py` — added `search/` URL pattern

No model or migration changes. Existing views are unchanged.

## How to Test

1. Run the new search tests:
   ```bash
   python manage.py test slideshows.tests.views.test_SlideshowSearchView -v2
   ```

2. Run the full slideshows test suite to confirm no regressions:
   ```bash
   python manage.py test slideshows -v2
   ```

3. Manual testing via Swagger (`/swagger/`) or curl:
   ```bash
   # Basic search
   curl -H "Authorization: Bearer <token>" "http://localhost:8000/api/slideshows/search/?q=python"

   # Search with filters
   curl -H "Authorization: Bearer <token>" "http://localhost:8000/api/slideshows/search/?q=python&subject=computer_science&mine=true"

   # Validation errors
   curl -H "Authorization: Bearer <token>" "http://localhost:8000/api/slideshows/search/?q=a"  # 400 - too short
   curl "http://localhost:8000/api/slideshows/search/?q=python"  # 401 - unauthenticated
   ```

4. Verify the endpoint appears correctly in `/swagger/` and `/redoc/` under the "Slideshows" tag.
