### PR TITLE
Add accept/decline endpoints for course invitations

### DIFF
--- a/backend/EduLite/courses/tests/test_api_enrollment.py
+++ b/backend/EduLite/courses/tests/test_api_enrollment.py
@@ -196,3 +196,189 @@ class CourseEnrollAPITests(APITestCase):
         response = self.client.delete(self._enroll_url(self.public_course))
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class CourseInvitationAcceptDeclineAPITests(APITestCase):
+    """Validate POST on /api/courses/<pk>/enroll/accept/ and /enroll/decline/."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user_model = get_user_model()
+
+        cls.teacher = cls._make_user("inv_teacher", "teacher")
+        cls.invited_user = cls._make_user("inv_student", "student")
+        cls.other_user = cls._make_user("inv_other", "student")
+
+        cls.course = Course.objects.create(
+            title="Invitation Test Course",
+            visibility="private",
+            start_date=datetime(2025, 1, 1),
+            end_date=datetime(2025, 12, 31),
+        )
+        CourseMembership.objects.create(
+            course=cls.course,
+            user=cls.teacher,
+            role="teacher",
+            status="enrolled",
+        )
+
+    @classmethod
+    def _make_user(cls, username: str, occupation: Optional[str] = None):
+        user = cls.user_model.objects.create_user(
+            username=username, password="test-pass-123"
+        )
+        if occupation is not None:
+            profile = user.profile
+            profile.occupation = occupation
+            profile.save()
+        return user
+
+    def _accept_url(self, course):
+        return reverse("course-enroll-accept", kwargs={"pk": course.pk})
+
+    def _decline_url(self, course):
+        return reverse("course-enroll-decline", kwargs={"pk": course.pk})
+
+    def _create_invitation(self, user, course=None):
+        """Helper to create an invitation membership."""
+        return CourseMembership.objects.create(
+            course=course or self.course,
+            user=user,
+            role="student",
+            status="invited",
+        )
+
+    # --- Accept Invitation ---
+
+    def test_accept_invitation(self):
+        """User with status='invited' can accept, status becomes 'enrolled'."""
+        invitation = self._create_invitation(self.invited_user)
+        self.client.force_authenticate(user=self.invited_user)
+
+        response = self.client.post(self._accept_url(self.course))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["status"], "enrolled")
+        self.assertEqual(response.data["role"], "student")
+
+        invitation.refresh_from_db()
+        self.assertEqual(invitation.status, "enrolled")
+
+        # Cleanup
+        invitation.delete()
+
+    def test_accept_without_invitation(self):
+        """User with no invitation gets 404."""
+        self.client.force_authenticate(user=self.other_user)
+
+        response = self.client.post(self._accept_url(self.course))
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_accept_already_enrolled(self):
+        """User with status='enrolled' gets 404 (no invitation to accept)."""
+        membership = CourseMembership.objects.create(
+            course=self.course,
+            user=self.invited_user,
+            role="student",
+            status="enrolled",
+        )
+        self.client.force_authenticate(user=self.invited_user)
+
+        response = self.client.post(self._accept_url(self.course))
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        # Cleanup
+        membership.delete()
+
+    def test_accept_pending_gets_404(self):
+        """User with status='pending' gets 404 (not an invitation)."""
+        membership = CourseMembership.objects.create(
+            course=self.course,
+            user=self.invited_user,
+            role="student",
+            status="pending",
+        )
+        self.client.force_authenticate(user=self.invited_user)
+
+        response = self.client.post(self._accept_url(self.course))
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        # Cleanup
+        membership.delete()
+
+    def test_accept_unauthenticated(self):
+        """Unauthenticated request returns 401."""
+        response = self.client.post(self._accept_url(self.course))
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    # --- Decline Invitation ---
+
+    def test_decline_invitation(self):
+        """User with status='invited' can decline, membership is deleted."""
+        invitation = self._create_invitation(self.invited_user)
+        invitation_pk = invitation.pk
+        self.client.force_authenticate(user=self.invited_user)
+
+        response = self.client.post(self._decline_url(self.course))
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(CourseMembership.objects.filter(pk=invitation_pk).exists())
+
+    def test_decline_without_invitation(self):
+        """User with no invitation gets 404."""
+        self.client.force_authenticate(user=self.other_user)
+
+        response = self.client.post(self._decline_url(self.course))
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_decline_already_enrolled(self):
+        """User with status='enrolled' gets 404 (no invitation to decline)."""
+        membership = CourseMembership.objects.create(
+            course=self.course,
+            user=self.invited_user,
+            role="student",
+            status="enrolled",
+        )
+        self.client.force_authenticate(user=self.invited_user)
+
+        response = self.client.post(self._decline_url(self.course))
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        # Cleanup
+        membership.delete()
+
+    def test_decline_unauthenticated(self):
+        """Unauthenticated request returns 401."""
+        response = self.client.post(self._decline_url(self.course))
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    # --- Cross-user safety ---
+
+    def test_cannot_accept_other_users_invitation(self):
+        """User A cannot accept user B's invitation — endpoint only operates on request.user."""
+        self._create_invitation(self.invited_user)
+        self.client.force_authenticate(user=self.other_user)
+
+        response = self.client.post(self._accept_url(self.course))
+
+        # other_user has no invitation, so 404
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        # invited_user's invitation is unchanged
+        self.assertTrue(
+            CourseMembership.objects.filter(
+                course=self.course, user=self.invited_user, status="invited"
+            ).exists()
+        )
+
+        # Cleanup
+        CourseMembership.objects.filter(
+            course=self.course, user=self.invited_user
+        ).delete()

--- a/backend/EduLite/courses/urls.py
+++ b/backend/EduLite/courses/urls.py
@@ -3,6 +3,8 @@ from django.urls import path
 from .views import (
     CourseDetailView,
     CourseEnrollView,
+    CourseInvitationAcceptView,
+    CourseInvitationDeclineView,
     CourseListCreateView,
     CourseMembershipDetailView,
     CourseMembershipListInviteView,
@@ -37,5 +39,15 @@ urlpatterns = [
         "courses/<int:pk>/enroll/",
         CourseEnrollView.as_view(),
         name="course-enroll",
+    ),
+    path(
+        "courses/<int:pk>/enroll/accept/",
+        CourseInvitationAcceptView.as_view(),
+        name="course-enroll-accept",
+    ),
+    path(
+        "courses/<int:pk>/enroll/decline/",
+        CourseInvitationDeclineView.as_view(),
+        name="course-enroll-decline",
     ),
 ]


### PR DESCRIPTION
# Add Accept/Decline Endpoints for Course Invitations

## Description

Adds two new endpoints so invited users can accept or decline course invitations themselves, instead of relying on a teacher to change their status via the membership management endpoint.

- `POST /api/courses/{id}/enroll/accept/` — accepts an invitation (status "invited" -> "enrolled")
- `POST /api/courses/{id}/enroll/decline/` — declines an invitation (membership deleted)

This unblocks the frontend EnrollmentActions component's Accept/Decline buttons which are currently disabled with a "coming soon" tooltip.

Closes #265

## Mandatory Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/ibrahim-sisar/EduLite/blob/main/CONTRIBUTING.md)
- [x] I have linked the related issue above
- [x] My branch is up to date with `main`
- [x] I have tested my changes locally
- [x] I have added or updated tests where applicable
- [x] I have not introduced any new linting errors
- [x] My commit messages are clear and descriptive
- [x] I have updated documentation if my changes affect public APIs, setup steps, or user-facing behavior

## What Changed

**`courses/views.py`** — Added two new views:
- `CourseInvitationAcceptView` — looks up the requesting user's `status="invited"` membership, updates to `"enrolled"`, returns 200 with serialized membership
- `CourseInvitationDeclineView` — looks up the requesting user's `status="invited"` membership, deletes it, returns 204

Both inherit from `CoursesAppBaseAPIView`, use `@transaction.atomic`, and have full `@extend_schema` OpenAPI documentation.

**`courses/urls.py`** — Added two URL patterns:
- `courses/<int:pk>/enroll/accept/`
- `courses/<int:pk>/enroll/decline/`

**`courses/tests/test_api_enrollment.py`** — Added 10 new tests in `CourseInvitationAcceptDeclineAPITests`:
- Accept: success, no invitation, already enrolled, pending status, unauthenticated
- Decline: success, no invitation, already enrolled, unauthenticated
- Cross-user safety: cannot accept another user's invitation

No model or migration changes.

## How to Test

1. Run the enrollment tests:
   ```bash
   python manage.py test courses.tests.test_api_enrollment -v2
   ```

2. Run the full courses test suite to confirm no regressions:
   ```bash
   python manage.py test courses -v2
   ```

3. Manual testing via Swagger (`/swagger/`) or curl:
   ```bash
   # First, have a teacher invite a user (creates membership with status="invited")
   # Then as the invited user:

   # Accept invitation
   curl -X POST -H "Authorization: Bearer <token>" "http://localhost:8000/api/courses/1/enroll/accept/"
   # 200 — {"id": ..., "status": "enrolled", "role": "student", ...}

   # Decline invitation
   curl -X POST -H "Authorization: Bearer <token>" "http://localhost:8000/api/courses/1/enroll/decline/"
   # 204 — No Content

   # No invitation
   curl -X POST -H "Authorization: Bearer <token>" "http://localhost:8000/api/courses/1/enroll/accept/"
   # 404 — {"detail": "No invitation found for this course."}
   ```

4. Verify the endpoints appear in `/swagger/` under the "Course Enrollment" tag.
