### PR TITLE
add courses to profile page

### DIFF
--- a/Frontend/EduLiteFrontend/src/i18n/locales/ar.json
+++ b/Frontend/EduLiteFrontend/src/i18n/locales/ar.json
@@ -491,6 +491,17 @@
       "leaveSuccess": "تمت مغادرة الدورة بنجاح",
       "lastTeacherTooltip": "أنت المعلم الوحيد — لا يمكنك مغادرة هذه الدورة",
       "networkError": "فشل تحديث التسجيل. يرجى المحاولة مرة أخرى."
+    },
+    "profile": {
+      "emptyTitle": "لا توجد دورات بعد",
+      "emptyMessage": "لم تسجل في أي دورة بعد.",
+      "browseCourses": "تصفح الدورات",
+      "viewAll": "عرض جميع الدورات",
+      "memberCount": "{{count}} أعضاء",
+      "roleTeacher": "معلم",
+      "roleStudent": "طالب",
+      "roleAssistant": "مساعد",
+      "errorLoading": "فشل تحميل الدورات"
     }
   }
 }

--- a/Frontend/EduLiteFrontend/src/i18n/locales/en.json
+++ b/Frontend/EduLiteFrontend/src/i18n/locales/en.json
@@ -490,6 +490,17 @@
       "leaveSuccess": "Successfully left the course",
       "lastTeacherTooltip": "You are the only teacher — you cannot leave this course",
       "networkError": "Failed to update enrollment. Please try again."
+    },
+    "profile": {
+      "emptyTitle": "No Courses Yet",
+      "emptyMessage": "You're not enrolled in any courses yet.",
+      "browseCourses": "Browse Courses",
+      "viewAll": "View All Courses",
+      "memberCount": "{{count}} members",
+      "roleTeacher": "Teacher",
+      "roleStudent": "Student",
+      "roleAssistant": "Assistant",
+      "errorLoading": "Failed to load courses"
     }
   }
 }


### PR DESCRIPTION
# Wire Up the Courses Tab on the Profile Page

## Description

Replaces the "Coming Soon" placeholder in the Profile page's Courses tab with a real list of the user's enrolled courses. Follows the existing Slideshows tab pattern for consistency.

Closes #250

## Mandatory Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/ibrahim-sisar/EduLite/blob/main/CONTRIBUTING.md)
- [x] I have linked the related issue above
- [x] My branch is up to date with `main`
- [x] I have tested my changes locally
- [x] I have added or updated tests where applicable
- [x] I have not introduced any new linting errors
- [x] My commit messages are clear and descriptive
- [x] I have updated documentation if my changes affect public APIs, setup steps, or user-facing behavior

## What Changed

**3 files changed** (113 insertions, 3 deletions)

**`ProfilePage.tsx`** — Main change:
- Added `courses`, `coursesLoading`, `coursesFetched` state (mirrors existing slideshows pattern)
- Lazy-loads courses via `listCourses({ mine: true })` on first Courses tab click
- Three UI states:
  - **Loading** — spinner
  - **Empty** — graduation cap icon, friendly message, "Browse Courses" button linking to `/courses`
  - **Data** — clickable course cards showing title, color-coded role badge (Teacher=blue, Student=green, Assistant=purple), subject, and member count
- "View All Courses" link at the bottom of the list
- Removed `courses` from the "Coming Soon" fallback block
- Added `useTranslation` hook (wasn't previously used in this file)

**`en.json` + `ar.json`** — Added `course.profile.*` translation keys for empty state, role badges, member count, and error messages.

## How to Test

1. Log in and go to `/profile`
2. Click the **Courses** tab
3. **If you have courses:** verify they display with correct titles, role badges, subjects, and member counts. Click a course title — should navigate to `/courses/{id}`
4. **If you have no courses:** verify the empty state message ("No Courses Yet") and "Browse Courses" button linking to `/courses`
5. Verify the loading spinner appears briefly while fetching
6. Toggle **dark mode** — verify all elements (badges, text, backgrounds) are styled correctly
7. Resize to **mobile** — verify responsive layout
8. Switch language to **Arabic** — verify translated text appears
9. Click away from Courses tab and back — should show cached data without re-fetching

## Screenshots (if applicable)

<img width="410" height="535" alt="image" src="https://github.com/user-attachments/assets/b13ca354-fc09-4275-abc4-3d8d9100d566" />
