### PR TITLE
261 frontend build invite member ux with user search autocomplete

### DIFF
--- a/Frontend/EduLiteFrontend/src/components/common/UserSearchInput.tsx
+++ b/Frontend/EduLiteFrontend/src/components/common/UserSearchInput.tsx
@@ -1,0 +1,306 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { HiMagnifyingGlass, HiXMark } from "react-icons/hi2";
+import { useDebounce } from "../../hooks/useDebounce";
+import { searchUsers } from "../../services/usersApi";
+import type { UserSearchResult } from "../../types/users.types";
+
+interface UserSearchInputProps {
+  onSelect: (user: UserSearchResult) => void;
+  selectedUser: UserSearchResult | null;
+  onClear: () => void;
+  placeholder?: string;
+  disabled?: boolean;
+  error?: string;
+  label?: string;
+}
+
+const UserSearchInput: React.FC<UserSearchInputProps> = ({
+  onSelect,
+  selectedUser,
+  onClear,
+  placeholder,
+  disabled = false,
+  error,
+  label,
+}) => {
+  const { t } = useTranslation();
+  const [query, setQuery] = useState("");
+  const debouncedQuery = useDebounce(query, 300);
+  const [results, setResults] = useState<UserSearchResult[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const [activeIndex, setActiveIndex] = useState(-1);
+
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  // Fetch results when debounced query changes
+  useEffect(() => {
+    if (debouncedQuery.length < 2) {
+      setResults([]);
+      setIsOpen(false);
+      setSearchError(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const fetchResults = async () => {
+      setIsLoading(true);
+      setSearchError(null);
+      try {
+        const data = await searchUsers({ q: debouncedQuery, page_size: 8 });
+        if (!cancelled) {
+          setResults(data.results);
+          setIsOpen(true);
+          setActiveIndex(-1);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setSearchError(
+            err instanceof Error
+              ? err.message
+              : t("course.detail.inviteModal.searchError"),
+          );
+          setResults([]);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    fetchResults();
+    return () => {
+      cancelled = true;
+    };
+  }, [debouncedQuery, t]);
+
+  // Click outside to close
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        wrapperRef.current &&
+        !wrapperRef.current.contains(e.target as Node)
+      ) {
+        setIsOpen(false);
+        setActiveIndex(-1);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  // Scroll active item into view
+  useEffect(() => {
+    if (activeIndex >= 0 && listRef.current) {
+      const activeItem = listRef.current.children[activeIndex] as HTMLElement;
+      activeItem?.scrollIntoView?.({ block: "nearest" });
+    }
+  }, [activeIndex]);
+
+  const handleSelect = useCallback(
+    (user: UserSearchResult) => {
+      onSelect(user);
+      setQuery("");
+      setResults([]);
+      setIsOpen(false);
+      setActiveIndex(-1);
+    },
+    [onSelect],
+  );
+
+  const handleClear = useCallback(() => {
+    onClear();
+    setQuery("");
+    setResults([]);
+    setSearchError(null);
+    // Focus input after clearing
+    setTimeout(() => inputRef.current?.focus(), 0);
+  }, [onClear]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!isOpen || results.length === 0) {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        (e.target as HTMLInputElement).blur();
+      }
+      return;
+    }
+
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setActiveIndex((prev) => (prev >= results.length - 1 ? 0 : prev + 1));
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setActiveIndex((prev) => (prev <= 0 ? results.length - 1 : prev - 1));
+        break;
+      case "Enter":
+        e.preventDefault();
+        if (activeIndex >= 0 && activeIndex < results.length) {
+          handleSelect(results[activeIndex]);
+        }
+        break;
+      case "Escape":
+        e.preventDefault();
+        e.stopPropagation();
+        setIsOpen(false);
+        setActiveIndex(-1);
+        break;
+      case "Tab":
+        setIsOpen(false);
+        setActiveIndex(-1);
+        break;
+    }
+  };
+
+  const resolvedLabel = label || t("course.detail.inviteModal.searchLabel");
+  const resolvedPlaceholder =
+    placeholder || t("course.detail.inviteModal.searchPlaceholder");
+
+  return (
+    <div className="space-y-1">
+      {resolvedLabel && (
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+          {resolvedLabel}
+        </label>
+      )}
+
+      <div ref={wrapperRef} className="relative">
+        {selectedUser ? (
+          // Selected user pill
+          <div className="flex items-center gap-2 px-3 py-2.5 bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-700/50 rounded-xl">
+            <div className="flex-1 min-w-0">
+              <span className="text-sm font-medium text-blue-800 dark:text-blue-200 truncate block">
+                {selectedUser.username}
+              </span>
+              {selectedUser.full_name && (
+                <span className="text-xs text-blue-600 dark:text-blue-300/70 truncate block">
+                  {selectedUser.full_name}
+                </span>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={handleClear}
+              disabled={disabled}
+              className="p-1 text-blue-400 hover:text-blue-600 dark:text-blue-300 dark:hover:text-blue-100 rounded-lg hover:bg-blue-100 dark:hover:bg-blue-800/50 transition-colors disabled:opacity-50 cursor-pointer"
+              aria-label={t("course.detail.inviteModal.clearSelection")}
+            >
+              <HiXMark className="w-4 h-4" />
+            </button>
+          </div>
+        ) : (
+          // Search input
+          <>
+            <div className="relative">
+              <HiMagnifyingGlass className="absolute start-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+              <input
+                ref={inputRef}
+                type="search"
+                role="combobox"
+                aria-expanded={isOpen}
+                aria-controls="user-search-listbox"
+                aria-activedescendant={
+                  activeIndex >= 0
+                    ? `user-search-option-${results[activeIndex]?.id}`
+                    : undefined
+                }
+                aria-autocomplete="list"
+                aria-label={resolvedLabel}
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={handleKeyDown}
+                onFocus={() => {
+                  if (results.length > 0 && query.length >= 2) {
+                    setIsOpen(true);
+                  }
+                }}
+                placeholder={resolvedPlaceholder}
+                disabled={disabled}
+                className="w-full ps-9 pe-9 py-2.5 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-xl shadow-sm text-gray-700 dark:text-gray-200 placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-400 transition-all duration-200 disabled:opacity-60 disabled:cursor-not-allowed"
+              />
+              {isLoading && (
+                <div className="absolute end-3 top-1/2 -translate-y-1/2">
+                  <div
+                    className="w-4 h-4 border-2 border-blue-400 border-t-transparent rounded-full animate-spin"
+                    role="status"
+                    aria-label="Loading"
+                  />
+                </div>
+              )}
+            </div>
+
+            {/* Dropdown */}
+            {isOpen && results.length > 0 && (
+              <ul
+                id="user-search-listbox"
+                ref={listRef}
+                role="listbox"
+                aria-label={t("course.detail.inviteModal.searchResults")}
+                className="absolute z-10 mt-1 w-full max-h-60 overflow-y-auto bg-white dark:bg-gray-800 border border-gray-200/50 dark:border-gray-700/30 rounded-xl shadow-lg"
+              >
+                {results.map((user, index) => (
+                  <li
+                    key={user.id}
+                    id={`user-search-option-${user.id}`}
+                    role="option"
+                    aria-selected={index === activeIndex}
+                    onClick={() => handleSelect(user)}
+                    onMouseEnter={() => setActiveIndex(index)}
+                    className={`px-4 py-3 cursor-pointer transition-colors ${
+                      index === activeIndex
+                        ? "bg-blue-50 dark:bg-blue-900/20"
+                        : "hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                    }`}
+                  >
+                    <span className="text-sm font-medium text-gray-900 dark:text-white truncate block">
+                      {user.username}
+                    </span>
+                    {user.full_name && (
+                      <span className="text-xs text-gray-500 dark:text-gray-400 truncate block">
+                        {user.full_name}
+                      </span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            {/* No results */}
+            {isOpen &&
+              !isLoading &&
+              debouncedQuery.length >= 2 &&
+              results.length === 0 &&
+              !searchError && (
+                <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                  {t("course.detail.inviteModal.noResults")}
+                </p>
+              )}
+
+            {/* Min chars hint */}
+            {query.length > 0 && query.length < 2 && !isLoading && (
+              <p className="mt-1 text-sm text-gray-400 dark:text-gray-500">
+                {t("course.detail.inviteModal.searchMinChars")}
+              </p>
+            )}
+          </>
+        )}
+
+        {/* Error messages */}
+        {(searchError || error) && (
+          <p className="mt-1 text-sm text-red-500">{searchError || error}</p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default UserSearchInput;

--- a/Frontend/EduLiteFrontend/src/components/common/__tests__/UserSearchInput.test.tsx
+++ b/Frontend/EduLiteFrontend/src/components/common/__tests__/UserSearchInput.test.tsx
@@ -1,0 +1,508 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "../../../test/utils";
+import UserSearchInput from "../UserSearchInput";
+import type { UserSearchResult } from "../../../types/users.types";
+
+// Mock the usersApi module
+vi.mock("../../../services/usersApi", () => ({
+  searchUsers: vi.fn(),
+}));
+
+import { searchUsers } from "../../../services/usersApi";
+
+const mockSearchUsers = vi.mocked(searchUsers);
+
+const mockResults: UserSearchResult[] = [
+  {
+    id: 1,
+    username: "john_doe",
+    full_name: "John Doe",
+    email: "john@example.com",
+    first_name: "John",
+    last_name: "Doe",
+    profile_id: 10,
+  },
+  {
+    id: 2,
+    username: "jane_doe",
+    full_name: "Jane Doe",
+    profile_id: 11,
+  },
+  {
+    id: 3,
+    username: "private_user",
+    profile_id: 12,
+  },
+];
+
+const defaultProps = {
+  onSelect: vi.fn(),
+  selectedUser: null,
+  onClear: vi.fn(),
+};
+
+describe("UserSearchInput", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mockSearchUsers.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("Rendering", () => {
+    it("renders search input with placeholder", () => {
+      renderWithProviders(<UserSearchInput {...defaultProps} />);
+      expect(
+        screen.getByPlaceholderText("Type a username or name..."),
+      ).toBeInTheDocument();
+    });
+
+    it("renders label when provided", () => {
+      renderWithProviders(
+        <UserSearchInput {...defaultProps} label="Find a user" />,
+      );
+      expect(screen.getByText("Find a user")).toBeInTheDocument();
+    });
+
+    it("renders selected user pill when selectedUser prop is set", () => {
+      renderWithProviders(
+        <UserSearchInput
+          {...defaultProps}
+          selectedUser={mockResults[0]}
+        />,
+      );
+      expect(screen.getByText("john_doe")).toBeInTheDocument();
+      expect(screen.getByText("John Doe")).toBeInTheDocument();
+      // Search input should not be visible
+      expect(
+        screen.queryByPlaceholderText("Type a username or name..."),
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders disabled state correctly", () => {
+      renderWithProviders(
+        <UserSearchInput {...defaultProps} disabled={true} />,
+      );
+      expect(
+        screen.getByPlaceholderText("Type a username or name..."),
+      ).toBeDisabled();
+    });
+
+    it("renders external error message", () => {
+      renderWithProviders(
+        <UserSearchInput {...defaultProps} error="Something went wrong" />,
+      );
+      expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    });
+  });
+
+  describe("Search Behavior", () => {
+    it("does not search when query is less than 2 characters", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      renderWithProviders(<UserSearchInput {...defaultProps} />);
+
+      await user.type(
+        screen.getByPlaceholderText("Type a username or name..."),
+        "a",
+      );
+      await act(() => vi.advanceTimersByTime(400));
+
+      expect(mockSearchUsers).not.toHaveBeenCalled();
+    });
+
+    it("shows min chars hint when typing 1 character", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      renderWithProviders(<UserSearchInput {...defaultProps} />);
+
+      await user.type(
+        screen.getByPlaceholderText("Type a username or name..."),
+        "a",
+      );
+
+      expect(
+        screen.getByText("Type at least 2 characters to search"),
+      ).toBeInTheDocument();
+    });
+
+    it("debounces search input by 300ms", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      mockSearchUsers.mockResolvedValue({
+        count: 1,
+        next: null,
+        previous: null,
+        results: [mockResults[0]],
+      });
+
+      renderWithProviders(<UserSearchInput {...defaultProps} />);
+
+      await user.type(
+        screen.getByPlaceholderText("Type a username or name..."),
+        "john",
+      );
+
+      // Not called yet — debounce hasn't fired
+      expect(mockSearchUsers).not.toHaveBeenCalled();
+
+      // Advance past debounce
+      await act(() => vi.advanceTimersByTime(350));
+
+      expect(mockSearchUsers).toHaveBeenCalledWith({
+        q: "john",
+        page_size: 8,
+      });
+    });
+
+    it("displays search results in dropdown", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      mockSearchUsers.mockResolvedValue({
+        count: 3,
+        next: null,
+        previous: null,
+        results: mockResults,
+      });
+
+      renderWithProviders(<UserSearchInput {...defaultProps} />);
+
+      await user.type(
+        screen.getByPlaceholderText("Type a username or name..."),
+        "doe",
+      );
+      await act(() => vi.advanceTimersByTime(350));
+
+      await waitFor(() => {
+        expect(screen.getByText("john_doe")).toBeInTheDocument();
+        expect(screen.getByText("jane_doe")).toBeInTheDocument();
+        expect(screen.getByText("private_user")).toBeInTheDocument();
+      });
+    });
+
+    it("shows no results message when search returns empty", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      mockSearchUsers.mockResolvedValue({
+        count: 0,
+        next: null,
+        previous: null,
+        results: [],
+      });
+
+      renderWithProviders(<UserSearchInput {...defaultProps} />);
+
+      await user.type(
+        screen.getByPlaceholderText("Type a username or name..."),
+        "nonexistent",
+      );
+      await act(() => vi.advanceTimersByTime(350));
+
+      await waitFor(() => {
+        expect(screen.getByText("No users found")).toBeInTheDocument();
+      });
+    });
+
+    it("shows error message on API failure", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      mockSearchUsers.mockRejectedValue(new Error("Network error"));
+
+      renderWithProviders(<UserSearchInput {...defaultProps} />);
+
+      await user.type(
+        screen.getByPlaceholderText("Type a username or name..."),
+        "test",
+      );
+      await act(() => vi.advanceTimersByTime(350));
+
+      await waitFor(() => {
+        expect(screen.getByText("Network error")).toBeInTheDocument();
+      });
+    });
+
+    it("only shows username for privacy-hidden users", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      mockSearchUsers.mockResolvedValue({
+        count: 1,
+        next: null,
+        previous: null,
+        results: [mockResults[2]], // private_user with no full_name
+      });
+
+      renderWithProviders(<UserSearchInput {...defaultProps} />);
+
+      await user.type(
+        screen.getByPlaceholderText("Type a username or name..."),
+        "private",
+      );
+      await act(() => vi.advanceTimersByTime(350));
+
+      await waitFor(() => {
+        expect(screen.getByText("private_user")).toBeInTheDocument();
+      });
+
+      // Ensure no "undefined" or empty full_name text
+      const listbox = screen.getByRole("listbox");
+      expect(listbox.textContent).not.toContain("undefined");
+    });
+  });
+
+  describe("Selection", () => {
+    it("calls onSelect when clicking a result", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      const onSelect = vi.fn();
+      mockSearchUsers.mockResolvedValue({
+        count: 1,
+        next: null,
+        previous: null,
+        results: [mockResults[0]],
+      });
+
+      renderWithProviders(
+        <UserSearchInput {...defaultProps} onSelect={onSelect} />,
+      );
+
+      await user.type(
+        screen.getByPlaceholderText("Type a username or name..."),
+        "john",
+      );
+      await act(() => vi.advanceTimersByTime(350));
+
+      await waitFor(() => {
+        expect(screen.getByText("john_doe")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText("john_doe"));
+      expect(onSelect).toHaveBeenCalledWith(mockResults[0]);
+    });
+
+    it("closes dropdown after selection", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      mockSearchUsers.mockResolvedValue({
+        count: 2,
+        next: null,
+        previous: null,
+        results: [mockResults[0], mockResults[1]],
+      });
+
+      renderWithProviders(<UserSearchInput {...defaultProps} />);
+
+      await user.type(
+        screen.getByPlaceholderText("Type a username or name..."),
+        "doe",
+      );
+      await act(() => vi.advanceTimersByTime(350));
+
+      await waitFor(() => {
+        expect(screen.getByRole("listbox")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText("john_doe"));
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+
+    it("calls onClear when clicking clear button on pill", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      const onClear = vi.fn();
+
+      renderWithProviders(
+        <UserSearchInput
+          {...defaultProps}
+          selectedUser={mockResults[0]}
+          onClear={onClear}
+        />,
+      );
+
+      await user.click(
+        screen.getByRole("button", { name: /clear selection/i }),
+      );
+      expect(onClear).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Keyboard Navigation", () => {
+    const setupWithResults = async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      mockSearchUsers.mockResolvedValue({
+        count: 3,
+        next: null,
+        previous: null,
+        results: mockResults,
+      });
+
+      renderWithProviders(<UserSearchInput {...defaultProps} />);
+      const input = screen.getByPlaceholderText("Type a username or name...");
+
+      await user.type(input, "doe");
+      await act(() => vi.advanceTimersByTime(350));
+
+      await waitFor(() => {
+        expect(screen.getByRole("listbox")).toBeInTheDocument();
+      });
+
+      return { user, input };
+    };
+
+    it("highlights first result on ArrowDown", async () => {
+      const { user, input } = await setupWithResults();
+
+      await user.type(input, "{ArrowDown}");
+
+      const firstOption = screen.getByText("john_doe").closest("[role='option']");
+      expect(firstOption).toHaveAttribute("aria-selected", "true");
+    });
+
+    it("wraps to first item when ArrowDown at end", async () => {
+      const { user, input } = await setupWithResults();
+
+      // Navigate to end
+      await user.type(input, "{ArrowDown}{ArrowDown}{ArrowDown}");
+      // One more should wrap to first
+      await user.type(input, "{ArrowDown}");
+
+      const firstOption = screen.getByText("john_doe").closest("[role='option']");
+      expect(firstOption).toHaveAttribute("aria-selected", "true");
+    });
+
+    it("wraps to last item when ArrowUp at beginning", async () => {
+      const { user, input } = await setupWithResults();
+
+      await user.type(input, "{ArrowUp}");
+
+      const lastOption = screen.getByText("private_user").closest("[role='option']");
+      expect(lastOption).toHaveAttribute("aria-selected", "true");
+    });
+
+    it("selects highlighted result on Enter", async () => {
+      const onSelect = vi.fn();
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      mockSearchUsers.mockResolvedValue({
+        count: 3,
+        next: null,
+        previous: null,
+        results: mockResults,
+      });
+
+      renderWithProviders(
+        <UserSearchInput {...defaultProps} onSelect={onSelect} />,
+      );
+      const input = screen.getByPlaceholderText("Type a username or name...");
+
+      await user.type(input, "doe");
+      await act(() => vi.advanceTimersByTime(350));
+
+      await waitFor(() => {
+        expect(screen.getByRole("listbox")).toBeInTheDocument();
+      });
+
+      await user.type(input, "{ArrowDown}{Enter}");
+      expect(onSelect).toHaveBeenCalledWith(mockResults[0]);
+    });
+
+    it("closes dropdown on Escape", async () => {
+      const { user, input } = await setupWithResults();
+
+      await user.type(input, "{Escape}");
+
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Click Outside", () => {
+    it("closes dropdown when clicking outside the component", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      mockSearchUsers.mockResolvedValue({
+        count: 1,
+        next: null,
+        previous: null,
+        results: [mockResults[0]],
+      });
+
+      renderWithProviders(
+        <div>
+          <UserSearchInput {...defaultProps} />
+          <button>Outside</button>
+        </div>,
+      );
+
+      await user.type(
+        screen.getByPlaceholderText("Type a username or name..."),
+        "john",
+      );
+      await act(() => vi.advanceTimersByTime(350));
+
+      await waitFor(() => {
+        expect(screen.getByRole("listbox")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText("Outside"));
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Accessibility", () => {
+    it("has combobox role on input", () => {
+      renderWithProviders(<UserSearchInput {...defaultProps} />);
+      expect(screen.getByRole("combobox")).toBeInTheDocument();
+    });
+
+    it("has aria-expanded matching dropdown state", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      mockSearchUsers.mockResolvedValue({
+        count: 1,
+        next: null,
+        previous: null,
+        results: [mockResults[0]],
+      });
+
+      renderWithProviders(<UserSearchInput {...defaultProps} />);
+      const combobox = screen.getByRole("combobox");
+
+      expect(combobox).toHaveAttribute("aria-expanded", "false");
+
+      await user.type(combobox, "john");
+      await act(() => vi.advanceTimersByTime(350));
+
+      await waitFor(() => {
+        expect(combobox).toHaveAttribute("aria-expanded", "true");
+      });
+    });
+
+    it("has listbox role on dropdown", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      mockSearchUsers.mockResolvedValue({
+        count: 1,
+        next: null,
+        previous: null,
+        results: [mockResults[0]],
+      });
+
+      renderWithProviders(<UserSearchInput {...defaultProps} />);
+
+      await user.type(screen.getByRole("combobox"), "john");
+      await act(() => vi.advanceTimersByTime(350));
+
+      await waitFor(() => {
+        expect(screen.getByRole("listbox")).toBeInTheDocument();
+      });
+    });
+
+    it("has option role on each result item", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      mockSearchUsers.mockResolvedValue({
+        count: 2,
+        next: null,
+        previous: null,
+        results: [mockResults[0], mockResults[1]],
+      });
+
+      renderWithProviders(<UserSearchInput {...defaultProps} />);
+
+      await user.type(screen.getByRole("combobox"), "doe");
+      await act(() => vi.advanceTimersByTime(350));
+
+      await waitFor(() => {
+        expect(screen.getAllByRole("option")).toHaveLength(2);
+      });
+    });
+  });
+});

--- a/Frontend/EduLiteFrontend/src/components/courses/InviteMemberModal.tsx
+++ b/Frontend/EduLiteFrontend/src/components/courses/InviteMemberModal.tsx
@@ -1,7 +1,11 @@
+import { useState, useEffect } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { HiUserPlus } from "react-icons/hi2";
 import type { CourseRole } from "../../types/courses.types";
+import type { UserSearchResult } from "../../types/users.types";
+import UserSearchInput from "../common/UserSearchInput";
+import HardLoadSelect from "../common/HardLoadSelect";
 
 interface InviteMemberModalProps {
   isOpen: boolean;
@@ -9,41 +13,158 @@ interface InviteMemberModalProps {
   onSubmit: (userId: number, role: CourseRole) => Promise<void>;
 }
 
+const ROLE_CHOICES: Array<[string, string]> = [
+  ["student", "Student"],
+  ["assistant", "Assistant"],
+  ["teacher", "Teacher"],
+];
+
 const InviteMemberModal: React.FC<InviteMemberModalProps> = ({
   isOpen,
   onClose,
+  onSubmit,
 }) => {
   const { t } = useTranslation();
+  const [selectedUser, setSelectedUser] = useState<UserSearchResult | null>(
+    null,
+  );
+  const [selectedRole, setSelectedRole] = useState<CourseRole>("student");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Reset state when modal closes
+  useEffect(() => {
+    if (!isOpen) {
+      setSelectedUser(null);
+      setSelectedRole("student");
+      setIsSubmitting(false);
+      setSubmitError(null);
+    }
+  }, [isOpen]);
+
+  const handleSubmit = async () => {
+    if (!selectedUser) return;
+
+    setIsSubmitting(true);
+    setSubmitError(null);
+
+    try {
+      await onSubmit(selectedUser.id, selectedRole);
+      onClose();
+    } catch (err) {
+      setSubmitError(
+        err instanceof Error
+          ? err.message
+          : t("course.detail.inviteModal.error"),
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleBackdropKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape" && !isSubmitting) {
+      onClose();
+    }
+  };
 
   if (!isOpen) return null;
 
   return createPortal(
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      onKeyDown={handleBackdropKeyDown}
+    >
       {/* Backdrop */}
       <div
         className="absolute inset-0 bg-black/50 backdrop-blur-sm"
-        onClick={onClose}
+        onClick={!isSubmitting ? onClose : undefined}
       />
 
       {/* Modal */}
-      <div className="relative bg-white dark:bg-gray-800 rounded-2xl shadow-2xl w-full max-w-md p-8 border border-gray-200/50 dark:border-gray-700/30 text-center">
-        <HiUserPlus className="w-16 h-16 text-blue-400 dark:text-blue-500 mx-auto mb-4 opacity-60" />
-
-        <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
-          {t("course.detail.inviteModal.title")}
-        </h2>
-
-        <p className="text-gray-500 dark:text-gray-400 mb-6">
-          {t("course.detail.inviteModal.comingSoon")}
-        </p>
-
+      <div className="relative bg-white dark:bg-gray-800 rounded-2xl shadow-2xl w-full max-w-sm sm:max-w-md p-6 sm:p-8 border border-gray-200/50 dark:border-gray-700/30 max-h-[90vh] overflow-y-auto">
+        {/* Close button */}
         <button
           type="button"
           onClick={onClose}
-          className="px-6 py-2.5 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 rounded-xl font-medium transition-colors cursor-pointer"
+          disabled={isSubmitting}
+          className="absolute top-4 end-4 p-1.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors disabled:opacity-50 cursor-pointer"
+          aria-label={t("common.close")}
         >
-          {t("common.close")}
+          <svg
+            className="w-5 h-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
         </button>
+
+        {/* Header */}
+        <div className="text-center mb-6">
+          <HiUserPlus className="w-12 h-12 text-blue-400 dark:text-blue-500 mx-auto mb-3 opacity-70" />
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+            {t("course.detail.inviteModal.title")}
+          </h2>
+        </div>
+
+        {/* User search */}
+        <div className="space-y-4">
+          <UserSearchInput
+            onSelect={setSelectedUser}
+            selectedUser={selectedUser}
+            onClear={() => setSelectedUser(null)}
+            label={t("course.detail.inviteModal.searchLabel")}
+            placeholder={t("course.detail.inviteModal.searchPlaceholder")}
+            disabled={isSubmitting}
+          />
+
+          {/* Role selector */}
+          <HardLoadSelect
+            label={t("course.detail.inviteModal.roleLabel")}
+            name="invite-role"
+            value={selectedRole}
+            onChange={(e) => setSelectedRole(e.target.value as CourseRole)}
+            choices={ROLE_CHOICES}
+            disabled={isSubmitting}
+          />
+
+          {/* Submit error */}
+          {submitError && (
+            <p className="text-sm text-red-500 text-center">{submitError}</p>
+          )}
+
+          {/* Action buttons */}
+          <div className="flex flex-col-reverse sm:flex-row gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={isSubmitting}
+              className="flex-1 px-4 py-2.5 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 rounded-xl font-medium transition-colors disabled:opacity-50 cursor-pointer"
+            >
+              {t("course.detail.inviteModal.cancel")}
+            </button>
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={!selectedUser || isSubmitting}
+              className="flex-1 px-4 py-2.5 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer flex items-center justify-center gap-2"
+            >
+              {isSubmitting && (
+                <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+              )}
+              {isSubmitting
+                ? t("course.detail.inviteModal.sending")
+                : t("course.detail.inviteModal.submitButton")}
+            </button>
+          </div>
+        </div>
       </div>
     </div>,
     document.body,

--- a/Frontend/EduLiteFrontend/src/components/courses/__tests__/InviteMemberModal.test.tsx
+++ b/Frontend/EduLiteFrontend/src/components/courses/__tests__/InviteMemberModal.test.tsx
@@ -1,0 +1,341 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "../../../test/utils";
+import InviteMemberModal from "../InviteMemberModal";
+import type { UserSearchResult } from "../../../types/users.types";
+
+// Mock the usersApi module
+vi.mock("../../../services/usersApi", () => ({
+  searchUsers: vi.fn(),
+}));
+
+import { searchUsers } from "../../../services/usersApi";
+
+const mockSearchUsers = vi.mocked(searchUsers);
+
+const mockResults: UserSearchResult[] = [
+  {
+    id: 1,
+    username: "john_doe",
+    full_name: "John Doe",
+    profile_id: 10,
+  },
+  {
+    id: 2,
+    username: "jane_doe",
+    full_name: "Jane Doe",
+    profile_id: 11,
+  },
+];
+
+const defaultProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  onSubmit: vi.fn(),
+};
+
+describe("InviteMemberModal", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mockSearchUsers.mockReset();
+    defaultProps.onClose.mockReset();
+    defaultProps.onSubmit.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("Rendering", () => {
+    it("renders nothing when isOpen is false", () => {
+      const { container } = renderWithProviders(
+        <InviteMemberModal {...defaultProps} isOpen={false} />,
+      );
+      expect(container.innerHTML).toBe("");
+    });
+
+    it("renders modal with title when isOpen is true", () => {
+      renderWithProviders(<InviteMemberModal {...defaultProps} />);
+      expect(screen.getByText("Invite Member")).toBeInTheDocument();
+    });
+
+    it("renders search input and role selector", () => {
+      renderWithProviders(<InviteMemberModal {...defaultProps} />);
+      expect(
+        screen.getByPlaceholderText("Type a username or name..."),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Role")).toBeInTheDocument();
+    });
+
+    it("renders Send Invite button disabled initially", () => {
+      renderWithProviders(<InviteMemberModal {...defaultProps} />);
+      expect(
+        screen.getByRole("button", { name: /send invite/i }),
+      ).toBeDisabled();
+    });
+
+    it("renders Cancel button", () => {
+      renderWithProviders(<InviteMemberModal {...defaultProps} />);
+      expect(
+        screen.getByRole("button", { name: /cancel/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("Full Invite Flow", () => {
+    it("search -> select user -> pick role -> submit succeeds", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      const onSubmit = vi.fn().mockResolvedValue(undefined);
+      const onClose = vi.fn();
+
+      mockSearchUsers.mockResolvedValue({
+        count: 2,
+        next: null,
+        previous: null,
+        results: mockResults,
+      });
+
+      renderWithProviders(
+        <InviteMemberModal
+          isOpen={true}
+          onClose={onClose}
+          onSubmit={onSubmit}
+        />,
+      );
+
+      // 1. Type username and wait for search
+      await user.type(
+        screen.getByPlaceholderText("Type a username or name..."),
+        "doe",
+      );
+      await act(() => vi.advanceTimersByTime(350));
+
+      // 2. Click a result
+      await waitFor(() => {
+        expect(screen.getByText("john_doe")).toBeInTheDocument();
+      });
+      await user.click(screen.getByText("john_doe"));
+
+      // 3. Change role to assistant
+      const roleSelect = document.querySelector(
+        'select[name="invite-role"]',
+      ) as HTMLSelectElement;
+      await user.selectOptions(roleSelect, "assistant");
+
+      // 4. Click Send Invite
+      const submitButton = screen.getByRole("button", { name: /send invite/i });
+      expect(submitButton).toBeEnabled();
+      await user.click(submitButton);
+
+      // 5. Verify onSubmit called with correct args
+      expect(onSubmit).toHaveBeenCalledWith(1, "assistant");
+      await waitFor(() => {
+        expect(onClose).toHaveBeenCalled();
+      });
+    });
+
+    it("shows error when submit fails", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      const onSubmit = vi
+        .fn()
+        .mockRejectedValue(new Error("User is already a member"));
+
+      mockSearchUsers.mockResolvedValue({
+        count: 1,
+        next: null,
+        previous: null,
+        results: [mockResults[0]],
+      });
+
+      renderWithProviders(
+        <InviteMemberModal
+          isOpen={true}
+          onClose={vi.fn()}
+          onSubmit={onSubmit}
+        />,
+      );
+
+      // Search and select
+      await user.type(
+        screen.getByPlaceholderText("Type a username or name..."),
+        "john",
+      );
+      await act(() => vi.advanceTimersByTime(350));
+
+      await waitFor(() => {
+        expect(screen.getByText("john_doe")).toBeInTheDocument();
+      });
+      await user.click(screen.getByText("john_doe"));
+
+      // Submit
+      await user.click(screen.getByRole("button", { name: /send invite/i }));
+
+      // Error should be shown
+      await waitFor(() => {
+        expect(
+          screen.getByText("User is already a member"),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("shows sending text on button while submitting", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      let resolveSubmit: () => void;
+      const onSubmit = vi.fn().mockReturnValue(
+        new Promise<void>((resolve) => {
+          resolveSubmit = resolve;
+        }),
+      );
+
+      mockSearchUsers.mockResolvedValue({
+        count: 1,
+        next: null,
+        previous: null,
+        results: [mockResults[0]],
+      });
+
+      renderWithProviders(
+        <InviteMemberModal
+          isOpen={true}
+          onClose={vi.fn()}
+          onSubmit={onSubmit}
+        />,
+      );
+
+      // Search and select
+      await user.type(
+        screen.getByPlaceholderText("Type a username or name..."),
+        "john",
+      );
+      await act(() => vi.advanceTimersByTime(350));
+
+      await waitFor(() => {
+        expect(screen.getByText("john_doe")).toBeInTheDocument();
+      });
+      await user.click(screen.getByText("john_doe"));
+
+      // Submit
+      await user.click(screen.getByRole("button", { name: /send invite/i }));
+
+      // Should show "Sending..."
+      expect(screen.getByText("Sending...")).toBeInTheDocument();
+
+      // Resolve the submit
+      await act(async () => {
+        resolveSubmit!();
+      });
+    });
+  });
+
+  describe("Close and Reset", () => {
+    it("calls onClose when clicking Cancel", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      const onClose = vi.fn();
+
+      renderWithProviders(
+        <InviteMemberModal
+          isOpen={true}
+          onClose={onClose}
+          onSubmit={vi.fn()}
+        />,
+      );
+
+      await user.click(screen.getByRole("button", { name: /cancel/i }));
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it("calls onClose when clicking close button", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      const onClose = vi.fn();
+
+      renderWithProviders(
+        <InviteMemberModal
+          isOpen={true}
+          onClose={onClose}
+          onSubmit={vi.fn()}
+        />,
+      );
+
+      await user.click(screen.getByRole("button", { name: /close/i }));
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it("resets state when reopened", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+      mockSearchUsers.mockResolvedValue({
+        count: 1,
+        next: null,
+        previous: null,
+        results: [mockResults[0]],
+      });
+
+      const { rerender } = renderWithProviders(
+        <InviteMemberModal {...defaultProps} />,
+      );
+
+      // Search and select a user
+      await user.type(
+        screen.getByPlaceholderText("Type a username or name..."),
+        "john",
+      );
+      await act(() => vi.advanceTimersByTime(350));
+
+      await waitFor(() => {
+        expect(screen.getByText("john_doe")).toBeInTheDocument();
+      });
+      await user.click(screen.getByText("john_doe"));
+
+      // Verify user is selected (pill visible)
+      expect(screen.getByText("john_doe")).toBeInTheDocument();
+
+      // Close modal
+      rerender(<InviteMemberModal {...defaultProps} isOpen={false} />);
+
+      // Reopen modal
+      rerender(<InviteMemberModal {...defaultProps} isOpen={true} />);
+
+      // Should be back to empty search input
+      expect(
+        screen.getByPlaceholderText("Type a username or name..."),
+      ).toBeInTheDocument();
+      // Send Invite should be disabled again
+      expect(
+        screen.getByRole("button", { name: /send invite/i }),
+      ).toBeDisabled();
+    });
+  });
+
+  describe("Role Selection", () => {
+    it("defaults to student role", () => {
+      renderWithProviders(<InviteMemberModal {...defaultProps} />);
+      const roleSelect = document.querySelector(
+        'select[name="invite-role"]',
+      ) as HTMLSelectElement;
+      expect(roleSelect).toHaveValue("student");
+    });
+
+    it("allows changing role to assistant", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      renderWithProviders(<InviteMemberModal {...defaultProps} />);
+
+      const roleSelect = document.querySelector(
+        'select[name="invite-role"]',
+      ) as HTMLSelectElement;
+      await user.selectOptions(roleSelect, "assistant");
+      expect(roleSelect).toHaveValue("assistant");
+    });
+
+    it("allows changing role to teacher", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      renderWithProviders(<InviteMemberModal {...defaultProps} />);
+
+      const roleSelect = document.querySelector(
+        'select[name="invite-role"]',
+      ) as HTMLSelectElement;
+      await user.selectOptions(roleSelect, "teacher");
+      expect(roleSelect).toHaveValue("teacher");
+    });
+  });
+});

--- a/Frontend/EduLiteFrontend/src/i18n/locales/ar.json
+++ b/Frontend/EduLiteFrontend/src/i18n/locales/ar.json
@@ -447,14 +447,20 @@
       },
       "inviteModal": {
         "title": "دعوة عضو",
-        "comingSoon": "البحث عن المستخدمين ودعوتهم قادم قريباً. ستتمكن من البحث عن المستخدمين بالاسم ودعوتهم إلى دورتك.",
-        "userIdLabel": "رقم المستخدم",
-        "userIdPlaceholder": "أدخل رقم المستخدم",
+        "searchLabel": "البحث عن مستخدم",
+        "searchPlaceholder": "اكتب اسم المستخدم أو الاسم...",
+        "searchResults": "نتائج البحث",
+        "noResults": "لم يتم العثور على مستخدمين",
+        "searchMinChars": "اكتب حرفين على الأقل للبحث",
+        "searchError": "فشل البحث عن المستخدمين",
+        "selectedUser": "المستخدم المحدد",
+        "clearSelection": "مسح التحديد",
         "roleLabel": "الدور",
         "submitButton": "إرسال الدعوة",
         "sending": "جارٍ الإرسال...",
         "success": "تم إرسال الدعوة بنجاح",
-        "error": "فشل إرسال الدعوة"
+        "error": "فشل إرسال الدعوة",
+        "cancel": "إلغاء"
       },
       "addModuleModal": {
         "title": "إضافة وحدة",

--- a/Frontend/EduLiteFrontend/src/i18n/locales/en.json
+++ b/Frontend/EduLiteFrontend/src/i18n/locales/en.json
@@ -446,14 +446,20 @@
       },
       "inviteModal": {
         "title": "Invite Member",
-        "comingSoon": "User search and invite is coming soon. You'll be able to search for users by name and invite them to your course.",
-        "userIdLabel": "User ID",
-        "userIdPlaceholder": "Enter user ID",
+        "searchLabel": "Search for a user",
+        "searchPlaceholder": "Type a username or name...",
+        "searchResults": "Search results",
+        "noResults": "No users found",
+        "searchMinChars": "Type at least 2 characters to search",
+        "searchError": "Failed to search users",
+        "selectedUser": "Selected user",
+        "clearSelection": "Clear selection",
         "roleLabel": "Role",
         "submitButton": "Send Invite",
         "sending": "Sending...",
         "success": "Invitation sent successfully",
-        "error": "Failed to send invitation"
+        "error": "Failed to send invitation",
+        "cancel": "Cancel"
       },
       "addModuleModal": {
         "title": "Add Module",

--- a/Frontend/EduLiteFrontend/src/pages/__tests__/CourseDetailPage.test.tsx
+++ b/Frontend/EduLiteFrontend/src/pages/__tests__/CourseDetailPage.test.tsx
@@ -632,8 +632,13 @@ describe("CourseDetailPage", () => {
         expect(
           screen.getByRole("heading", { name: "Invite Member" }),
         ).toBeInTheDocument();
-        // Modal shows coming soon placeholder
-        expect(screen.getByText(/coming soon/i)).toBeInTheDocument();
+        // Modal shows search input and Send Invite button
+        expect(
+          screen.getByPlaceholderText("Type a username or name..."),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole("button", { name: /send invite/i }),
+        ).toBeInTheDocument();
       });
     });
   });

--- a/Frontend/EduLiteFrontend/src/services/__tests__/usersApi.test.ts
+++ b/Frontend/EduLiteFrontend/src/services/__tests__/usersApi.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
+import { searchUsers } from "../usersApi";
+
+describe("usersApi", () => {
+  let mock: MockAdapter;
+
+  beforeEach(() => {
+    mock = new MockAdapter(axios);
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  describe("searchUsers", () => {
+    it("should search users with query parameter", async () => {
+      const mockResponse = {
+        count: 2,
+        next: null,
+        previous: null,
+        results: [
+          {
+            id: 1,
+            username: "john_doe",
+            email: "john@example.com",
+            first_name: "John",
+            last_name: "Doe",
+            full_name: "John Doe",
+            profile_id: 10,
+          },
+          {
+            id: 2,
+            username: "johnny",
+            full_name: "Johnny Smith",
+            profile_id: 11,
+          },
+        ],
+      };
+
+      mock
+        .onGet("http://localhost:8000/api/users/search/", {
+          params: { q: "john" },
+        })
+        .reply(200, mockResponse);
+
+      const result = await searchUsers({ q: "john" });
+      expect(result).toEqual(mockResponse);
+      expect(result.results).toHaveLength(2);
+    });
+
+    it("should pass pagination parameters", async () => {
+      const mockResponse = {
+        count: 10,
+        next: "http://localhost:8000/api/users/search/?q=test&page=3",
+        previous: "http://localhost:8000/api/users/search/?q=test&page=1",
+        results: [
+          { id: 5, username: "tester5", profile_id: 50 },
+        ],
+      };
+
+      mock
+        .onGet("http://localhost:8000/api/users/search/", {
+          params: { q: "test", page: 2, page_size: 5 },
+        })
+        .reply(200, mockResponse);
+
+      const result = await searchUsers({ q: "test", page: 2, page_size: 5 });
+      expect(result.count).toBe(10);
+      expect(result.next).toContain("page=3");
+      expect(result.previous).toContain("page=1");
+    });
+
+    it("should handle empty results", async () => {
+      const mockResponse = {
+        count: 0,
+        next: null,
+        previous: null,
+        results: [],
+      };
+
+      mock
+        .onGet("http://localhost:8000/api/users/search/")
+        .reply(200, mockResponse);
+
+      const result = await searchUsers({ q: "nonexistent" });
+      expect(result.count).toBe(0);
+      expect(result.results).toHaveLength(0);
+    });
+
+    it("should handle results with privacy-hidden fields", async () => {
+      const mockResponse = {
+        count: 1,
+        next: null,
+        previous: null,
+        results: [
+          {
+            id: 3,
+            username: "private_user",
+            profile_id: 30,
+          },
+        ],
+      };
+
+      mock
+        .onGet("http://localhost:8000/api/users/search/")
+        .reply(200, mockResponse);
+
+      const result = await searchUsers({ q: "private" });
+      expect(result.results[0].username).toBe("private_user");
+      expect(result.results[0].email).toBeUndefined();
+      expect(result.results[0].full_name).toBeUndefined();
+    });
+
+    it("should handle 400 for short query", async () => {
+      mock
+        .onGet("http://localhost:8000/api/users/search/")
+        .reply(400, { q: ["Search query must be at least 2 characters."] });
+
+      await expect(searchUsers({ q: "a" })).rejects.toThrow();
+    });
+
+    it("should handle 500 server errors", async () => {
+      mock
+        .onGet("http://localhost:8000/api/users/search/")
+        .reply(500, { detail: "Internal server error" });
+
+      await expect(searchUsers({ q: "test" })).rejects.toThrow();
+    });
+
+    it("should handle network errors", async () => {
+      mock
+        .onGet("http://localhost:8000/api/users/search/")
+        .networkError();
+
+      await expect(searchUsers({ q: "test" })).rejects.toThrow();
+    });
+  });
+});

--- a/Frontend/EduLiteFrontend/src/services/usersApi.ts
+++ b/Frontend/EduLiteFrontend/src/services/usersApi.ts
@@ -1,0 +1,29 @@
+import axios from "axios";
+import { getSafeErrorMessage } from "../utils/errorUtils";
+import type {
+  UserSearchParams,
+  UserSearchPaginatedResponse,
+} from "../types/users.types";
+
+const API_BASE_URL = "http://localhost:8000/api";
+
+/**
+ * Search for users by username, first name, or last name.
+ * Privacy settings are respected — some fields may be absent.
+ *
+ * @param params - Search parameters (q required, min 2 chars)
+ * @returns Paginated list of matching users
+ */
+export const searchUsers = async (
+  params: UserSearchParams,
+): Promise<UserSearchPaginatedResponse> => {
+  try {
+    const response = await axios.get(`${API_BASE_URL}/users/search/`, {
+      params,
+      timeout: 10000,
+    });
+    return response.data;
+  } catch (error) {
+    throw new Error(getSafeErrorMessage(error, "Failed to search users"));
+  }
+};

--- a/Frontend/EduLiteFrontend/src/types/users.types.ts
+++ b/Frontend/EduLiteFrontend/src/types/users.types.ts
@@ -1,0 +1,34 @@
+/**
+ * A single user result from the search API.
+ * Mirrors backend UserSearchSerializer.
+ * Fields may be absent due to privacy settings.
+ */
+export interface UserSearchResult {
+  id: number;
+  username: string;
+  email?: string;
+  first_name?: string;
+  last_name?: string;
+  full_name?: string;
+  profile_id: number;
+}
+
+/**
+ * Query parameters for the user search endpoint.
+ */
+export interface UserSearchParams {
+  q: string;
+  page?: number;
+  page_size?: number;
+}
+
+/**
+ * Paginated response from the user search endpoint.
+ * Uses standard DRF PageNumberPagination (count, next, previous, results).
+ */
+export interface UserSearchPaginatedResponse {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: UserSearchResult[];
+}


### PR DESCRIPTION
# Build Invite Member UX with User Search Autocomplete

## Description

Replaces the placeholder "Coming Soon" invite modal with a fully functional invite flow. Teachers can now search for users by username or name, select a result from an autocomplete dropdown, pick a role, and send an invitation — all without leaving the course detail page.

Closes #261

## Mandatory Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/ibrahim-sisar/EduLite/blob/main/CONTRIBUTING.md)
- [x] I have linked the related issue above
- [x] My branch is up to date with `main`
- [x] I have tested my changes locally
- [x] I have added or updated tests where applicable
- [x] I have not introduced any new linting errors
- [x] My commit messages are clear and descriptive
- [x] I have updated documentation if my changes affect public APIs, setup steps, or user-facing behavior

## What Changed

### New Files

#### `src/types/users.types.ts`
- `UserSearchResult` — mirrors backend `UserSearchSerializer` with optional privacy-filtered fields (`email`, `first_name`, `last_name`, `full_name`)
- `UserSearchParams` — query parameters (`q`, `page`, `page_size`)
- `UserSearchPaginatedResponse` — standard DRF pagination shape (`count`, `next`, `previous`, `results`)

#### `src/services/usersApi.ts`
- `searchUsers(params)` — GET `/api/users/search/` with 10s timeout and `getSafeErrorMessage` error handling, matching the existing `coursesApi` pattern

#### `src/components/common/UserSearchInput.tsx`
Reusable autocomplete combobox component with:
- **Debounced search** — 300ms debounce via existing `useDebounce` hook, minimum 2 characters
- **Race condition handling** — `cancelled` flag pattern (same as `useCourses.ts`) prevents stale responses
- **Keyboard navigation** — ArrowUp/Down to highlight, Enter to select, Escape to close dropdown
- **Accessibility** — `role="combobox"`, `aria-expanded`, `aria-activedescendant`, `role="listbox"`/`role="option"` on dropdown items
- **Click-outside-to-close** — `mousedown` listener on document
- **Escape key layering** — dropdown captures Escape with `stopPropagation()` when open, so the parent modal only receives Escape when the dropdown is closed
- **Privacy-safe rendering** — shows only `username` when `full_name` is hidden by privacy settings
- **Selected user pill** — displays username + full name with a clear (X) button
- **RTL support** — all logical properties (`start-`/`end-`/`ps-`/`pe-`)

### Modified Files

#### `src/components/courses/InviteMemberModal.tsx` (rewrite)
Full invite flow replacing the placeholder:
- `UserSearchInput` for user selection
- `HardLoadSelect` for role picker (student/assistant/teacher, defaults to student)
- Submit button disabled until a user is selected, shows spinner during submission
- Error messages displayed inline on submit failure
- State resets when modal closes and reopens
- Responsive: `max-w-sm sm:max-w-md`, `flex-col-reverse sm:flex-row` button layout
- Props interface unchanged (`{ isOpen, onClose, onSubmit }`) — no changes needed to `MembersTab.tsx`

#### `src/i18n/locales/en.json`
Replaced old placeholder keys (`comingSoon`, `userIdLabel`, `userIdPlaceholder`) with new search UX keys: `searchLabel`, `searchPlaceholder`, `searchResults`, `noResults`, `searchMinChars`, `searchError`, `selectedUser`, `clearSelection`, `cancel`

#### `src/i18n/locales/ar.json`
Matching Arabic translations for all new keys

#### `src/pages/__tests__/CourseDetailPage.test.tsx`
Updated existing "opens invite modal" test to verify the search input and Send Invite button instead of the old "Coming Soon" text

### New Test Files

#### `src/services/__tests__/usersApi.test.ts` (7 tests)
- Searches with query parameter, pagination params, empty results, privacy-hidden fields, 400/500/network errors

#### `src/components/common/__tests__/UserSearchInput.test.tsx` (21 tests)
- Rendering: input, label, selected pill, disabled state, error message
- Search behavior: min chars guard, debounce timing, results display, no results, API error, privacy rendering
- Selection: click to select, dropdown closes, clear button
- Keyboard navigation: ArrowDown/Up highlight, wrap at boundaries, Enter to select, Escape to close
- Click outside: closes dropdown
- Accessibility: combobox role, aria-expanded, listbox role, option roles

#### `src/components/courses/__tests__/InviteMemberModal.test.tsx` (14 tests)
- Rendering: hidden when closed, title, search + role selector, disabled submit button, cancel button
- Full invite flow: search → select → pick role → submit succeeds, submit error shown, sending state
- Close and reset: cancel, close button, state resets on reopen
- Role selection: defaults to student, change to assistant/teacher

## How to Test

1. **Start the app**: `make up` or `cd Frontend/EduLiteFrontend && npm run dev`
2. **Log in** as a teacher of any course
3. **Navigate** to the course detail page → Members tab
4. **Click "Invite Member"** button

### Invite Flow
- Type 1 character — should show "Type at least 2 characters to search" hint
- Type 2+ characters — should show loading spinner, then results dropdown
- Click a result — dropdown closes, selected user pill appears with username + full name
- Click X on the pill — clears selection, input reappears
- Change role dropdown to "Assistant" or "Teacher"
- Click "Send Invite" — spinner on button, modal closes on success, toast appears
- If user is already a member — error message shown inline, modal stays open

### Keyboard Navigation
- Type a search, then use ArrowDown/Up to highlight results
- Press Enter to select the highlighted result
- Press Escape to close dropdown (modal stays open)
- Press Escape again to close modal

### RTL Testing
- Switch language to Arabic
- Verify search icon on correct side, clear button on correct side
- Dropdown items aligned properly
- Button layout flows correctly

### Run Tests
```bash
cd Frontend/EduLiteFrontend
npx tsc --noEmit    # No type errors
npm run lint        # No lint errors
npm run test        # 682 tests pass (33 files)
npx vite build      # Build succeeds
```

## Screenshots (if applicable)

<img width="604" height="676" alt="image" src="https://github.com/user-attachments/assets/0fa2c21b-0be7-444a-a71c-96bc46655d92" />

<img width="604" height="676" alt="image" src="https://github.com/user-attachments/assets/c76cb55e-85f0-4136-a815-c0b820aa4e87" />

